### PR TITLE
use official rosdistro, add jade

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -8,7 +8,12 @@ distributions:
       default: indigo/release-build.yaml
     source_builds:
       default: indigo/source-build.yaml
-      S32: indigo/source32-build.yaml
+  jade:
+    release_builds:
+      arm: jade/release-armhf-build.yaml
+      default: jade/release-build.yaml
+    source_builds:
+      default: jade/source-build.yaml
 jenkins_url: http://54.183.26.131:8080/
 notification_emails:
   - dthomas+buildfarm@osrfoundation.org
@@ -47,7 +52,7 @@ prerequisites:
     xaePFwP+okKW1h9qvwFhNF0JSCtdJrexdCf8jGE7
     =E8ot
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.github.com/ros/rosdistro/ec2test/index.yaml
+rosdistro_index_url: https://raw.github.com/ros/rosdistro/master/index.yaml
 status_page_repositories:
   default:
   - http://54.183.65.232/ubuntu/building

--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 83
-jenkins_binary_job_timeout: 120
+jenkins_binary_job_timeout: 480
 jenkins_source_job_priority: 81
 jenkins_source_job_timeout: 30
 notifications:

--- a/indigo/release-build.yaml
+++ b/indigo/release-build.yaml
@@ -2,41 +2,16 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 81
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 80
+jenkins_source_job_priority: 81
 jenkins_source_job_timeout: 30
 notifications:
   emails:
-  - dthomas+buildfarm@osrfoundation.org
+  - tfoote+buildfarm@osrfoundation.org
   maintainers: false
-package_blacklist:
-- combine_dr_measurements
-- hrpsys
-- icart_mini_driver
-- ira_photonfocus_driver
-- multisense
-- multisense_bringup
-- multisense_cal_check
-- multisense_description
-- multisense_lib
-- multisense_ros
-- nao_meshes
-- neo_base_mp_400
-- neo_base_mp_500
-- neo_relayboard
-- neo_watchdogs
-- ola_ros
-- openhrp3
-- pr2eus
-- swiftnav
-- ueye_cam
-- waypoints_navigation
-- yocs_ar_marker_tracking
-- yocs_ar_pair_tracking
-- yocs_waypoint_provider
 sync:
-  package_count: 150
+  package_count: 1000
 repositories:
   keys:
   - |

--- a/indigo/release-build.yaml
+++ b/indigo/release-build.yaml
@@ -11,7 +11,7 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: false
 sync:
-  package_count: 1000
+  package_count: 1300
 repositories:
   keys:
   - |

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -2,16 +2,16 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 82
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 81
+jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30
 notifications:
   emails:
-  - tfoote+buildfarm@osrfoundation.org
+  - william+buildfarm@osrfoundation.org
   maintainers: false
 sync:
-  package_count: 700
+  package_count: 140
 repositories:
   keys:
   - |

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 82
-jenkins_binary_job_timeout: 120
+jenkins_binary_job_timeout: 480
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30
 notifications:

--- a/jade/release-build.yaml
+++ b/jade/release-build.yaml
@@ -2,16 +2,16 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 82
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 81
+jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30
 notifications:
   emails:
-  - tfoote+buildfarm@osrfoundation.org
+  - william+buildfarm@osrfoundation.org
   maintainers: false
 sync:
-  package_count: 700
+  package_count: 140
 repositories:
   keys:
   - |
@@ -51,6 +51,13 @@ target_repository: http://54.183.65.232/ubuntu/building
 targets:
   ubuntu:
     trusty:
-      armhf:
+      amd64:
+      i386:
+    utopic:
+      amd64:
+      i386:
+    vivid:
+      amd64:
+      i386:
 type: release-build
 version: 2

--- a/jade/source-build.yaml
+++ b/jade/source-build.yaml
@@ -1,13 +1,13 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 71
+jenkins_commit_job_priority: 70
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 61
+jenkins_pull_request_job_priority: 60
 notifications:
   committers: false
   emails:
-  - tfoote+buildfarm@osrfoundation.org
+  - william+buildfarm@osrfoundation.org
   maintainers: false
 repositories:
   urls:


### PR DESCRIPTION
After merging this PR and running a full redeploy the test farm will use the official rosdistro and build Indigo and Jade. This depends on https://github.com/ros-infrastructure/buildfarm_deployment/issues/34 being deployed.

@tfoote Does the _Indigo_ configuration look good to you?

@wjwwood Does the _Jade_ configuration look good to you?

@esteve FYI (but no _Hydro_ jobs for you :wink:)
