### PR TITLE
Disable ueye_cam for ARM

### DIFF
--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -11,6 +11,8 @@ notifications:
   - ros-buildfarm-jade@googlegroups.com
   - william+buildfarm@osrfoundation.org
   maintainers: false
+package_blacklist:
+  - ueye_cam
 sync:
   package_count: 140
 repositories:


### PR DESCRIPTION
It explicitly says it does not support it and bails out at CMake time.

@dirk-thomas for review.
