### PR TITLE
blacklisting failing jobs from indigo and copying all to jade

### DIFF
--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -12,7 +12,63 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: false
 package_blacklist:
+  - ardrone_autonomy
+  - avt_vimba_camera
+  - baxter_ikfast_left_arm
+  - baxter_ikfast_right_arm
+  - bride
+  - epos_library
+  - eus_nlopt
+  - eus_qp
+  - gazebo_ros
+  - graspit
+  - h4r_x53_joyext
+  - homer_nav
+  - icar_mini
+  - imagesift
+  - jaco_sdk
+  - jinteractiveworld
+  - jsk_pcl_ros
+  - kdl_typekit
+  - libfovis
+  - libntcan
+  - libpointmatcher
+  - libsegwayrmp
+  - libvimba
+  - map_merger
   - mapviz
+  - micros_rtt
+  - multires_image
+  - nao_meshes
+  - naoqi_driver
+  - nav_pcontroller
+  - ndt_rviz
+  - neo_relayboard
+  - nerian_sp1
+  - octovis
+  - ola_ros
+  - openhrp3
+  - or_libs
+  - p2os_urdf
+  - pcan_topics
+  - pepper_meshes
+  - pointgrey_camera_driver
+  - pr2_motor_diagnostic_tool
+  - prosilica_gige_sdk
+  - qglv_gallery
+  - qglv_opengl
+  - riskrrt
+  - robot_calibration
+  - robot_face
+  - rosjava_bootstrap
+  - rospeex_core
+  - rostful_node
+  - sr_external_dependencies
+  - teb_local_planner
+  - uwsim
+  - uwsim_osgocean
+  - uwsim_osgworks
+  - visp
 sync:
   package_count: 700
 repositories:

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -12,8 +12,64 @@ notifications:
   - william+buildfarm@osrfoundation.org
   maintainers: false
 package_blacklist:
+  - ardrone_autonomy
+  - avt_vimba_camera
+  - baxter_ikfast_left_arm
+  - baxter_ikfast_right_arm
+  - bride
+  - epos_library
+  - eus_nlopt
+  - eus_qp
+  - gazebo_ros
+  - graspit
+  - h4r_x53_joyext
+  - homer_nav
+  - icar_mini
+  - imagesift
+  - jaco_sdk
+  - jinteractiveworld
+  - jsk_pcl_ros
+  - kdl_typekit
+  - libfovis
+  - libntcan
+  - libpointmatcher
+  - libsegwayrmp
+  - libvimba
+  - map_merger
   - mapviz
+  - micros_rtt
+  - multires_image
+  - nao_meshes
+  - naoqi_driver
+  - nav_pcontroller
+  - ndt_rviz
+  - neo_relayboard
+  - nerian_sp1
+  - octovis
+  - ola_ros
+  - openhrp3
+  - or_libs
+  - p2os_urdf
+  - pcan_topics
+  - pepper_meshes
+  - pointgrey_camera_driver
+  - pr2_motor_diagnostic_tool
+  - prosilica_gige_sdk
+  - qglv_gallery
+  - qglv_opengl
+  - riskrrt
+  - robot_calibration
+  - robot_face
+  - rosjava_bootstrap
+  - rospeex_core
+  - rostful_node
+  - sr_external_dependencies
+  - teb_local_planner
   - ueye_cam
+  - uwsim
+  - uwsim_osgocean
+  - uwsim_osgworks
+  - visp
 sync:
   package_count: 140
 repositories:


### PR DESCRIPTION
Follow on to #6 with all armhf jobs which failed last night. Culled from here: https://groups.google.com/forum/#!searchin/ros-buildfarm-indigo/failed and here: http://54.183.26.131:8080/view/Ibin_arm_uThf/

I'm assuming they won't work in jade either as these are arch specific failures just some are not released into jade yet. 
