### PR TITLE
disable pr builds on the test farm

### DIFF
--- a/indigo/source-build.yaml
+++ b/indigo/source-build.yaml
@@ -50,7 +50,9 @@ targets:
       amd64:
 test_commits:
   default: true
+# do not run pr builds on the test farm (otherwise we'll get multiple reports)
 test_pull_requests:
   default: false
+  force: false
 type: source-build
 version: 2

--- a/jade/source-build.yaml
+++ b/jade/source-build.yaml
@@ -50,7 +50,9 @@ targets:
       amd64:
 test_commits:
   default: true
+# do not run pr builds on the test farm (otherwise we'll get multiple reports)
 test_pull_requests:
   default: false
+  force: false
 type: source-build
 version: 2


### PR DESCRIPTION
So we don't get double reports
