### PR TITLE
fix canonical url of documentation

### DIFF
--- a/indigo/doc-build.yaml
+++ b/indigo/doc-build.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 # ROS buildfarm doc-build file
 ---
-canonical_base_url: http://repositories.ros.org/docs
+canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
 jenkins_job_priority: 91
 jenkins_job_timeout: 60

--- a/jade/doc-build.yaml
+++ b/jade/doc-build.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 # ROS buildfarm doc-build file
 ---
-canonical_base_url: http://repositories.ros.org/docs
+canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
 jenkins_job_priority: 90
 jenkins_job_timeout: 60


### PR DESCRIPTION
After merging this all doc jobs needs to be triggered with `force`.
