### PR TITLE
update doc timeouts

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -12,7 +12,7 @@ doc_repositories:
 - https://github.com/vcstools/rosinstall.git
 - https://github.com/vcstools/vcstools.git
 jenkins_job_priority: 90
-jenkins_job_timeout: 60
+jenkins_job_timeout: 30
 notifications:
   emails:
   - dthomas+buildfarm@osrfoundation.org

--- a/indigo/doc-build.yaml
+++ b/indigo/doc-build.yaml
@@ -4,7 +4,7 @@
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
 jenkins_job_priority: 91
-jenkins_job_timeout: 60
+jenkins_job_timeout: 120
 notifications:
   committers: false
   emails:

--- a/indigo/doc-released-build.yaml
+++ b/indigo/doc-released-build.yaml
@@ -3,7 +3,7 @@
 ---
 documentation_type: released_manifest
 jenkins_job_priority: 91
-jenkins_job_timeout: 60
+jenkins_job_timeout: 30
 notifications:
   emails:
   - ros-buildfarm-indigo@googlegroups.com

--- a/jade/doc-build.yaml
+++ b/jade/doc-build.yaml
@@ -4,7 +4,7 @@
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
 jenkins_job_priority: 90
-jenkins_job_timeout: 60
+jenkins_job_timeout: 120
 notifications:
   committers: false
   emails:

--- a/jade/doc-released-build.yaml
+++ b/jade/doc-released-build.yaml
@@ -3,7 +3,7 @@
 ---
 documentation_type: released_manifest
 jenkins_job_priority: 90
-jenkins_job_timeout: 60
+jenkins_job_timeout: 30
 notifications:
   emails:
   - ros-buildfarm-jade@googlegroups.com


### PR DESCRIPTION
Since `doc` jobs need to compile the code the timeout needs to be higher since several jobs don't finish in one hour.

The other doc related jobs are much faster and therefore the timeout was reduced.
