### PR TITLE
blacklist grasp_planning_graspit on armhf

### DIFF
--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -19,6 +19,7 @@ package_blacklist:
   - epos_library
   - eus_nlopt
   - gazebo_ros
+  - grasp_planning_graspit
   - graspit
   - imagesift
   - jaco_sdk

--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -50,6 +50,7 @@ package_blacklist:
   - rospeex_core
   - sr_external_dependencies
   - teb_local_planner
+  - urdf2graspit
   - uwsim
   - uwsim_osgocean
   - uwsim_osgworks


### PR DESCRIPTION
libsoqt4-dev does not seem to exist on armhf

The jobs are consistently failing with this error:

```
Looking for the '.dsc' file of package 'ros-indigo-grasp-planning-graspit' with version '0.1.4-0'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apt/cache.py", line 198, in __getitem__
    return self._weakref[key]
  File "/usr/lib/python3.4/weakref.py", line 125, in __getitem__
    o = self.data[key]()
KeyError: 'libsoqt4-dev'
```

FYI @JenniferBuehler 
