### PR TITLE
Enable email notifications for Kinetic ARM builds

### DIFF
--- a/kinetic/release-arm-build.yaml
+++ b/kinetic/release-arm-build.yaml
@@ -10,7 +10,7 @@ notifications:
   emails:
   - ros-buildfarm-kinetic@googlegroups.com
   - jackie+buildfarm@osrfoundation.org
-  maintainers: false
+  maintainers: true
 package_blacklist:
 sync:
   package_count: 1


### PR DESCRIPTION
I think @vrabaud pointed out that the arm builds on the Kinetic buildfarm do not send email notifications to anyone but me. This PR is for sharing the fun
