### PR TITLE
teb_local_planner armhf builds

### DIFF
--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -49,7 +49,6 @@ package_blacklist:
   - rosjava_bootstrap
   - rospeex_core
   - sr_external_dependencies
-  - teb_local_planner
   - urdf2graspit
   - uwsim
   - uwsim_osgocean

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -48,7 +48,6 @@ package_blacklist:
   - rosjava_bootstrap
   - rospeex_core
   - sr_external_dependencies
-  - teb_local_planner
   - ueye_cam
   - uwsim
   - uwsim_osgocean


### PR DESCRIPTION
Hi,

according to [teb_local_planner#4](https://github.com/rst-tu-dortmund/teb_local_planner/issues/4)
the armhf build issues should be fixed now. I've released the new version containing the fix recently.
Would it be possible to remove the teb_local_planner from the blacklist (indigo/jade) in order to verify,
if it compiles successfully now with the buildfarm?

Thank you!
