### PR TITLE
turn off documentation of jenkins_tools

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -4,7 +4,6 @@
 documentation_type: make_target
 doc_repositories:
 - https://github.com/ros-infrastructure/catkin_pkg.git
-- https://github.com/ros-infrastructure/jenkins_tools.git
 - https://github.com/ros-infrastructure/rep.git
 - https://github.com/ros-infrastructure/rosdep.git
 - https://github.com/ros-infrastructure/rosdistro.git


### PR DESCRIPTION
It's replaced by ros_buildfarm
