### PR TITLE
blacklist a few packages on kinetic

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -11,6 +11,9 @@ notifications:
   - ros-buildfarm-testfarm@googlegroups.com
   maintainers: false
 package_blacklist:
+  - ardrone_autonomy
+  - octovis
+  - ueye
 sync:
   package_count: 1
 repositories:


### PR DESCRIPTION
I am blacklisting packages that are failing to build for ARM on the Kinetic build farm that were also disabled for Jade or Indigo.

Maintainers, please contact us in the future if you have a solution for the failing arm builds and would like to reenable them on the farm. Thanks.

@mani-monaj (ardrone_autonomy)
@ahornung (octovis)
@kmhallen (ueye)
