### PR TITLE
Increase package sync limit

### DIFF
--- a/kinetic/release-arm-build.yaml
+++ b/kinetic/release-arm-build.yaml
@@ -16,7 +16,7 @@ package_blacklist:
   - octovis
   - ueye
 sync:
-  package_count: 200
+  package_count: 300
 repositories:
   keys:
   - |

--- a/kinetic/release-arm-build.yaml
+++ b/kinetic/release-arm-build.yaml
@@ -16,7 +16,7 @@ package_blacklist:
   - octovis
   - ueye
 sync:
-  package_count: 1
+  package_count: 200
 repositories:
   keys:
   - |

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - jackie+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 1
+  package_count: 300
 repositories:
   keys:
   - |

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - jackie+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 300
+  package_count: 330
 repositories:
   keys:
   - |


### PR DESCRIPTION
Should be merged after the imminent Kinetic sync (for desktop-full). I'm waiting on metapackages to finish building, as well as gazebo-ros-pkgs for Debian and Wily. I may also refine the numbers a bit based on the package status after the next sync.

http://repositories.ros.org/status_page/ros_kinetic_default.html?q=RED1
http://repositories.ros.org/status_page/ros_kinetic_arm.html?q=RED1
