### PR TITLE
Split up build config files for kinetic

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -36,7 +36,7 @@ distributions:
     release_builds:
       armhf: kinetic/release-armhf-build.yaml
       jessie: kinetic/release-jessie-build.yaml
-      jessie-arm64: kinetic/release-jessie-arm64-build.yaml
+      jarm64: kinetic/release-jessie-arm64-build.yaml
       default: kinetic/release-build.yaml
     source_builds:
       default: kinetic/source-build.yaml

--- a/index.yaml
+++ b/index.yaml
@@ -34,7 +34,7 @@ distributions:
     - ros-buildfarm-kinetic@googlegroups.com
     - jackie+buildfarm@osrfoundation.org
     release_builds:
-      arm: kinetic/release-arm-build.yaml
+      armhf: kinetic/release-armhf-build.yaml
       jessie: kinetic/release-jessie-build.yaml
       jessie-arm64: kinetic/release-jessie-arm64-build.yaml
       default: kinetic/release-build.yaml

--- a/index.yaml
+++ b/index.yaml
@@ -34,9 +34,9 @@ distributions:
     - ros-buildfarm-kinetic@googlegroups.com
     - jackie+buildfarm@osrfoundation.org
     release_builds:
-      armhf: kinetic/release-armhf-build.yaml
-      jessie: kinetic/release-jessie-build.yaml
-      jarm64: kinetic/release-jessie-arm64-build.yaml
+      uxhf: kinetic/release-armhf-build.yaml
+      dj: kinetic/release-jessie-build.yaml
+      djv8: kinetic/release-jessie-arm64-build.yaml
       default: kinetic/release-build.yaml
     source_builds:
       default: kinetic/source-build.yaml

--- a/index.yaml
+++ b/index.yaml
@@ -36,6 +36,7 @@ distributions:
     release_builds:
       arm: kinetic/release-arm-build.yaml
       jessie: kinetic/release-jessie-build.yaml
+      jessie-arm64: kinetic/release-jessie-arm64-build.yaml
       default: kinetic/release-build.yaml
     source_builds:
       default: kinetic/source-build.yaml

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -67,9 +67,6 @@ targets:
   ubuntu:
     xenial:
       armhf:
-  debian:
-    jessie:
-      arm64:
 type: release-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
 version: 2

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -57,9 +57,6 @@ targets:
     xenial:
       amd64:
       i386:
-  debian:
-    jessie:
-      amd64:
 type: release-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
 version: 2

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -13,6 +13,8 @@ notifications:
   maintainers: true
 package_blacklist:
   - ardrone_autonomy
+  - nao_meshes
+  - naoqi_driver
   - octovis
   - ueye
 sync:

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -1,0 +1,63 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 94
+jenkins_binary_job_timeout: 600
+jenkins_source_job_priority: 79
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-kinetic@googlegroups.com
+  - jackie+buildfarm@osrfoundation.org
+  maintainers: true
+package_blacklist:
+  - ardrone_autonomy
+  - octovis
+  - ueye
+sync:
+  package_count: 300
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  debian:
+    jessie:
+      arm64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2
+

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -1,54 +1,20 @@
 %YAML 1.1
-# ROS buildfarm index file
+# ROS buildfarm release-build file
 ---
-distributions:
-  indigo:
-    doc_builds:
-      default: indigo/doc-build.yaml
-      released-packages-without-doc-job: indigo/doc-released-build.yaml
-    notification_emails:
-    - ros-buildfarm-indigo@googlegroups.com
-    - tfoote+buildfarm@osrfoundation.org
-    release_builds:
-      arm: indigo/release-armhf-build.yaml
-      default: indigo/release-build.yaml
-    source_builds:
-      default: indigo/source-build.yaml
-  jade:
-    doc_builds:
-      default: jade/doc-build.yaml
-      released-packages-without-doc-job: jade/doc-released-build.yaml
-    notification_emails:
-    - ros-buildfarm-jade@googlegroups.com
-    - william+buildfarm@osrfoundation.org
-    release_builds:
-      arm: jade/release-armhf-build.yaml
-      default: jade/release-build.yaml
-    source_builds:
-      default: jade/source-build.yaml
-  kinetic:
-    doc_builds:
-      default: kinetic/doc-build.yaml
-      released-packages-without-doc-job: kinetic/doc-released-build.yaml
-    notification_emails:
-    - ros-buildfarm-kinetic@googlegroups.com
-    - jackie+buildfarm@osrfoundation.org
-    release_builds:
-      arm: kinetic/release-arm-build.yaml
-      jessie: kinetic/release-jessie-build.yaml
-      default: kinetic/release-build.yaml
-    source_builds:
-      default: kinetic/source-build.yaml
-doc_builds:
-  independent-packages: doc-independent-build.yaml
-jenkins_url: http://build.ros.org
-notification_emails:
-- ros-buildfarm@googlegroups.com
-- tfoote+buildfarm@osrfoundation.org
-prerequisites:
-  debian_repositories:
-  - http://repositories.ros.org/ubuntu/building
-  debian_repository_keys:
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 82
+jenkins_binary_job_timeout: 120
+jenkins_source_job_priority: 79
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-kinetic@googlegroups.com
+  - jackie+buildfarm@osrfoundation.org
+  maintainers: true
+sync:
+  package_count: 330
+repositories:
+  keys:
   - |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
     Version: GnuPG v1.4.11 (GNU/Linux)
@@ -80,11 +46,14 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
-status_page_repositories:
-  default:
+  urls:
   - http://repositories.ros.org/ubuntu/building
-  - http://repositories.ros.org/ubuntu/testing
-  - http://repositories.ros.org/ubuntu/main
-type: buildfarm
-version: 1
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  debian:
+    jessie:
+      amd64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2
+


### PR DESCRIPTION
As discussed with @tfoote and @wjwwood, we've decided to add multiple build config files to allow for finer-grained blacklisting policies. There should be four build types:
- Ubuntu x86/x64
- Ubuntu armhf
- Debian Jessie x86/x64
- Debian Jessie arm64

edit to correct William's username
