### PR TITLE
enable new compiler warnings option for Kinetic devel jobs

### DIFF
--- a/kinetic/source-build.yaml
+++ b/kinetic/source-build.yaml
@@ -6,6 +6,7 @@ jenkins_job_timeout: 120
 jenkins_pull_request_job_priority: 59
 notifications:
   committers: true
+  compiler_warnings: true
   emails:
   - ros-buildfarm-kinetic@googlegroups.com
   - jackie+buildfarm@osrfoundation.org


### PR DESCRIPTION
Depends on ros-infrastructure/ros_buildfarm#293
