### PR TITLE
blacklist ueye_cam for arm64 build

### DIFF
--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -17,6 +17,7 @@ package_blacklist:
   - naoqi_driver
   - octovis
   - ueye
+  - ueye_cam
 sync:
   package_count: 300
 repositories:


### PR DESCRIPTION
manufacturer (IDS) has not released aarch64 native drivers
