### PR TITLE
blacklist smarthome_network_wakeonlan

### DIFF
--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -65,6 +65,7 @@ package_blacklist:
   - rosjava_bootstrap
   - rospeex_core
   - rostful_node
+  - smarthome_network_wakeonlan
   - sr_external_dependencies
   - urdf2graspit
   - uwsim


### PR DESCRIPTION
This will keep it from attempting to rebuild on the farm

http://build.ros.org:8080/job/Ibin_arm_uThf__smarthome_network_wakeonlan__ubuntu_trusty_armhf__binary/

https://github.com/ros/rosdistro/pull/11690

Ticketed upstream
https://github.com/rosalfred/smarthome_network_wakeonlan/issues/1
