### PR TITLE
removing rtabmap from the blacklist

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -21,7 +21,6 @@ package_blacklist:
   - nerian_sp1
   - octovis
   - peppper_meshes
-  - rtabmap
   - schunk_canopen_driver
   - ueye
   - ueye_cam


### PR DESCRIPTION
Since pcl_conversions is not blacklisted anymore (https://github.com/ros-infrastructure/ros_buildfarm_config/commit/7aa31d40dfb80dad4965fe479846ee5e6f2f5e8b), rtabmap should be able to build.
