### PR TITLE
fix typo in pepper_meshes package name

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -20,7 +20,7 @@ package_blacklist:
   - naoqi_driver
   - nerian_sp1
   - octovis
-  - peppper_meshes
+  - pepper_meshes
   - schunk_canopen_driver
   - ueye
   - ueye_cam


### PR DESCRIPTION
fixes package name typo introduced in #58 
