### PR TITLE
un-blacklisting ueye_cam from armhf

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -23,7 +23,6 @@ package_blacklist:
   - pepper_meshes
   - schunk_canopen_driver
   - ueye
-  - ueye_cam
 sync:
   package_count: 300
 repositories:


### PR DESCRIPTION
ueye_cam was blacklisted previously in release-arm-build.yaml since it failed to build on arm64. This was carried over to the new release-armhf-build.yaml by default, although ueye_cam does indeed build under armhf (32-bit).