### PR TITLE
increment priorities to avoid overlap between source and binary jobs

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -10,7 +10,7 @@ doc_repositories:
 - https://github.com/ros-infrastructure/rospkg.git
 - https://github.com/vcstools/rosinstall.git
 - https://github.com/vcstools/vcstools.git
-jenkins_job_priority: 90
+jenkins_job_priority: 88
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/indigo/release-build.yaml
+++ b/indigo/release-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 86
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 82
 jenkins_source_job_timeout: 30

--- a/jade/release-build.yaml
+++ b/jade/release-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 84
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 81
 jenkins_source_job_timeout: 30

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 84
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 84
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/lunar/release-build.yaml
+++ b/lunar/release-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 82
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-stretch-build.yaml
+++ b/lunar/release-stretch-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 82
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30


### PR DESCRIPTION
indigo source jobs have the same priority as lunar binary jobs. This PR increment all binary jobs priority to avoid the overlap