### PR TITLE
Whitelist only cakin for debian builds

### DIFF
--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -12,74 +12,74 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: false
 package_blacklist:
-  - ardrone_autonomy
-  - aubo_driver
-  - avt_vimba_camera
-  - baxter_ikfast_left_arm_plugin
-  - baxter_ikfast_right_arm_plugin
-  - bride
-  - cob_cartesian_controller
-  - darknet
-  - epos_library
-  - eus_nlopt
-  - eus_qp
-  - gazebo_ros
-  - grasp_planning_graspit
-  - graspit
-  - h4r_x52_joyext
-  - homer_nav_libs
-  - icart_mini_driver
-  - imagesift
-  - jaco_sdk
-  - jinteractiveworld
-  - jsk_data
-  - jsk_maps
-  - jsk_pcl_ros
-  - kdl_typekit
-  - libfovis
-  - libntcan
-  - libpointmatcher
-  - libsegwayrmp
-  - libvimba
-  - map_merger
-  - mapviz
-  - mecanum_gazebo_plugin
-  - micros_rtt
-  - multires_image
-  - nao_meshes
-  - naoqi_dcm_driver
-  - naoqi_driver
-  - nav_pcontroller
-  - ndt_rviz_visualisation
-  - neo_relayboard
-  - nerian_sp1
-  - octovis
-  - oculus_sdk
-  - ola_ros
-  - openhrp3
-  - openrave
-  - or_libs
-  - p2os_urdf
-  - pcan_topics
-  - pepper_meshes
-  - pointgrey_camera_driver
-  - pr2_motor_diagnostic_tool
-  - prosilica_gige_sdk
-  - qglv_gallery
-  - qglv_opengl
-  - riskrrt
-  - robot_calibration
-  - robot_face
-  - rosjava_bootstrap
-  - rospeex_core
-  - rostful_node
-  - smarthome_network_wakeonlan
-  - sr_external_dependencies
-  - urdf2graspit
-  - urdf2inventor
-  - uwsim
-  - uwsim_osgocean
-  - uwsim_osgworks
+- ardrone_autonomy
+- aubo_driver
+- avt_vimba_camera
+- baxter_ikfast_left_arm_plugin
+- baxter_ikfast_right_arm_plugin
+- bride
+- cob_cartesian_controller
+- darknet
+- epos_library
+- eus_nlopt
+- eus_qp
+- gazebo_ros
+- grasp_planning_graspit
+- graspit
+- h4r_x52_joyext
+- homer_nav_libs
+- icart_mini_driver
+- imagesift
+- jaco_sdk
+- jinteractiveworld
+- jsk_data
+- jsk_maps
+- jsk_pcl_ros
+- kdl_typekit
+- libfovis
+- libntcan
+- libpointmatcher
+- libsegwayrmp
+- libvimba
+- map_merger
+- mapviz
+- mecanum_gazebo_plugin
+- micros_rtt
+- multires_image
+- nao_meshes
+- naoqi_dcm_driver
+- naoqi_driver
+- nav_pcontroller
+- ndt_rviz_visualisation
+- neo_relayboard
+- nerian_sp1
+- octovis
+- oculus_sdk
+- ola_ros
+- openhrp3
+- openrave
+- or_libs
+- p2os_urdf
+- pcan_topics
+- pepper_meshes
+- pointgrey_camera_driver
+- pr2_motor_diagnostic_tool
+- prosilica_gige_sdk
+- qglv_gallery
+- qglv_opengl
+- riskrrt
+- robot_calibration
+- robot_face
+- rosjava_bootstrap
+- rospeex_core
+- rostful_node
+- smarthome_network_wakeonlan
+- sr_external_dependencies
+- urdf2graspit
+- urdf2inventor
+- uwsim
+- uwsim_osgocean
+- uwsim_osgworks
 sync:
   package_count: 1500
 repositories:

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -12,66 +12,66 @@ notifications:
   - william+buildfarm@osrfoundation.org
   maintainers: false
 package_blacklist:
-  - ardrone_autonomy
-  - avt_vimba_camera
-  - baxter_ikfast_left_arm_plugin
-  - baxter_ikfast_right_arm_plugin
-  - bride
-  - darknet
-  - epos_library
-  - eus_nlopt
-  - eus_qp
-  - gazebo_ros
-  - graspit
-  - h4r_x52_joyext
-  - homer_nav_libs
-  - icar_mini
-  - imagesift
-  - jaco_sdk
-  - jinteractiveworld
-  - jsk_pcl_ros
-  - kdl_typekit
-  - libfovis
-  - libntcan
-  - libpointmatcher
-  - libsegwayrmp
-  - libvimba
-  - map_merger
-  - mapviz
-  - micros_rtt
-  - multires_image
-  - nao_meshes
-  - naoqi_dcm_driver
-  - naoqi_driver
-  - nav_pcontroller
-  - ndt_rviz_visualisation
-  - neo_relayboard
-  - nerian_sp1
-  - octovis
-  - oculus_sdk
-  - ola_ros
-  - openhrp3
-  - or_libs
-  - p2os_urdf
-  - pcan_topics
-  - pepper_meshes
-  - pointgrey_camera_driver
-  - pr2_motor_diagnostic_tool
-  - prosilica_gige_sdk
-  - qglv_gallery
-  - qglv_opengl
-  - riskrrt
-  - robot_calibration
-  - robot_face
-  - rosjava_bootstrap
-  - rospeex_core
-  - rostful_node
-  - rtabmap_ros
-  - sr_external_dependencies
-  - ueye_cam
-  - uwsim
-  - uwsim_osgocean
-  - uwsim_osgworks
+- ardrone_autonomy
+- avt_vimba_camera
+- baxter_ikfast_left_arm_plugin
+- baxter_ikfast_right_arm_plugin
+- bride
+- darknet
+- epos_library
+- eus_nlopt
+- eus_qp
+- gazebo_ros
+- graspit
+- h4r_x52_joyext
+- homer_nav_libs
+- icar_mini
+- imagesift
+- jaco_sdk
+- jinteractiveworld
+- jsk_pcl_ros
+- kdl_typekit
+- libfovis
+- libntcan
+- libpointmatcher
+- libsegwayrmp
+- libvimba
+- map_merger
+- mapviz
+- micros_rtt
+- multires_image
+- nao_meshes
+- naoqi_dcm_driver
+- naoqi_driver
+- nav_pcontroller
+- ndt_rviz_visualisation
+- neo_relayboard
+- nerian_sp1
+- octovis
+- oculus_sdk
+- ola_ros
+- openhrp3
+- or_libs
+- p2os_urdf
+- pcan_topics
+- pepper_meshes
+- pointgrey_camera_driver
+- pr2_motor_diagnostic_tool
+- prosilica_gige_sdk
+- qglv_gallery
+- qglv_opengl
+- riskrrt
+- robot_calibration
+- robot_face
+- rosjava_bootstrap
+- rospeex_core
+- rostful_node
+- rtabmap_ros
+- sr_external_dependencies
+- ueye_cam
+- uwsim
+- uwsim_osgocean
+- uwsim_osgworks
 sync:
   package_count: 750
 repositories:

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -12,18 +12,18 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
-  - ardrone_autonomy
-  - darknet
-  - hrpsys
-  - mapviz
-  - nao_meshes
-  - naoqi_dcm_driver
-  - naoqi_driver
-  - nerian_sp1
-  - octovis
-  - pepper_meshes
-  - schunk_canopen_driver
-  - ueye
+- ardrone_autonomy
+- darknet
+- hrpsys
+- mapviz
+- nao_meshes
+- naoqi_dcm_driver
+- naoqi_driver
+- nerian_sp1
+- octovis
+- pepper_meshes
+- schunk_canopen_driver
+- ueye
 sync:
   package_count: 300
 repositories:

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -12,18 +12,18 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
-  - ardrone_autonomy
-  - hrpsys
-  - nao_meshes
-  - naoqi_dcm_driver
-  - naoqi_driver
-  - nerian_sp1
-  - octovis
-  - pepper_meshes
-  - rqt_multiplot
-  - schunk_canopen_driver
-  - ueye
-  - ueye_cam
+- ardrone_autonomy
+- hrpsys
+- nao_meshes
+- naoqi_dcm_driver
+- naoqi_driver
+- nerian_sp1
+- octovis
+- pepper_meshes
+- rqt_multiplot
+- schunk_canopen_driver
+- ueye
+- ueye_cam
 sync:
   package_count: 300
 repositories:

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -12,8 +12,8 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
-  - rqt_multiplot
-  - schunk_canopen_driver
+- rqt_multiplot
+- schunk_canopen_driver
 sync:
   package_count: 330
 repositories:

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -12,18 +12,18 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: false
 package_blacklist:
-  - ardrone_autonomy
-  - hrpsys
-  - nao_meshes
-  - naoqi_dcm_driver
-  - naoqi_driver
-  - nerian_sp1
-  - octovis
-  - pepper_meshes
-  - rqt_multiplot
-  - schunk_canopen_driver
-  - ueye
-  - ueye_cam
+- ardrone_autonomy
+- hrpsys
+- nao_meshes
+- naoqi_dcm_driver
+- naoqi_driver
+- nerian_sp1
+- octovis
+- pepper_meshes
+- rqt_multiplot
+- schunk_canopen_driver
+- ueye
+- ueye_cam
 sync:
   package_count: 300
 repositories:

--- a/lunar/release-stretch-build.yaml
+++ b/lunar/release-stretch-build.yaml
@@ -12,6 +12,8 @@ notifications:
   - mikael+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+package_whitelist:
+  - catkin
 sync:
   package_count: 1
 repositories:

--- a/lunar/release-stretch-build.yaml
+++ b/lunar/release-stretch-build.yaml
@@ -13,7 +13,7 @@ notifications:
   maintainers: true
 package_blacklist:
 package_whitelist:
-  - catkin
+- catkin
 sync:
   package_count: 1
 repositories:


### PR DESCRIPTION
Build only catkin for stretch until https://github.com/ros-infrastructure/ros_buildfarm/pull/374 or allternative solution is merged
Rationale: 
- Avoid maintainers to be spammed for failing jobs they can't fix
- Prevent buildfarm for building failing jobs and cause starvation for other jobs
