### PR TITLE
whitelist catkin only on debian arm builds

### DIFF
--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -12,6 +12,8 @@ notifications:
   - mikael+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+package_whitelist:
+- catkin
 sync:
   package_count: 1
 repositories:


### PR DESCRIPTION
addresses https://github.com/ros-infrastructure/ros_buildfarm_config/pull/75#issuecomment-281846394

@tfoote we may need to purge the existing artefacts from the farm for the source ubuntu jobs to turn over. Do you think we can do that ?