### PR TITLE
Blacklist octovis on xenial armhf

### DIFF
--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - mikael+buildfarm@osrfoundation.org
   maintainers: false
 package_blacklist:
+- octovis
 sync:
   package_count: 100
 repositories:


### PR DESCRIPTION
This PR blacklists octovis on ubuntu xenial armhf because octovis's dependency [libqglviewer-dev-qt4](http://packages.ubuntu.com/xenial/libqglviewer-dev-qt4) doesn't axist on armhf.