### PR TITLE
enable email notification for xenial arm jobs on lunar

### DIFF
--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -10,7 +10,7 @@ notifications:
   emails:
   - ros-buildfarm-lunar@googlegroups.com
   - mikael+buildfarm@osrfoundation.org
-  maintainers: false
+  maintainers: true
 package_blacklist:
 sync:
   package_count: 300

--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -10,7 +10,7 @@ notifications:
   emails:
   - ros-buildfarm-lunar@googlegroups.com
   - mikael+buildfarm@osrfoundation.org
-  maintainers: false
+  maintainers: true
 package_blacklist:
 - octovis
 sync:


### PR DESCRIPTION
follow up of https://github.com/ros-infrastructure/ros_buildfarm/issues/447

@tfoote feel free to comment here if these notifications should not be enabled (I noticed that they were disabled for [armhf on indigo](https://github.com/ros-infrastructure/ros_buildfarm_config/blob/d881efc74db3a5e330421fe1523d9ba0a05f93f0/indigo/release-armhf-build.yaml#L13) and [jade](https://github.com/ros-infrastructure/ros_buildfarm_config/blob/d881efc74db3a5e330421fe1523d9ba0a05f93f0/jade/release-armhf-build.yaml#L13) and also disabled for [xenial arm64 on kinetic](https://github.com/ros-infrastructure/ros_buildfarm_config/blob/d881efc74db3a5e330421fe1523d9ba0a05f93f0/kinetic/release-xenial-arm64-build.yaml#L13))