### PR TITLE
Blacklist rospilot from Jessie

### DIFF
--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+- rospilot
 - rqt_multiplot
 - schunk_canopen_driver
 sync:


### PR DESCRIPTION
Debian has stopped updating the NPM package, and dropped it
from Stretch