### PR TITLE
increase arm jobs timeout to 12 hours

### DIFF
--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 97
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 82
 jenkins_source_job_timeout: 30
 notifications:

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 96
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 81
 jenkins_source_job_timeout: 30
 notifications:

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 95
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30
 notifications:

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 95
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30
 notifications:

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 95
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30
 notifications:

--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 94
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30
 notifications:

--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 94
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30
 notifications:

--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 94
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30
 notifications:


### PR DESCRIPTION
Some arm jobs are genuinely hitting the timeout or finish within minutes before the 10-hour timeout.
This bump the timeout of arm jobs to 12 hours. Even if we havent reached the limit on all distros/architecture/platform combination I bumped them all for consistency.
The downside being that hanging jobs will be blocking executors for 2 more hours now.

Examples of jobs (almost) hitting the timeout:
http://build.ros.org/view/Lbin_dsv8_dSv8/job/Lbin_dsv8_dSv8__libg2o__debian_stretch_arm64__binary/2/
http://build.ros.org/view/Lbin_dsv8_dSv8/job/Lbin_dsv8_dSv8__opencv3__debian_stretch_arm64__binary/7/
http://build.ros.org/view/Kbin_uxhf_uXhf/job/Kbin_uxhf_uXhf__ecto_ros__ubuntu_xenial_armhf__binary/32/
http://build.ros.org/view/Kbin_uxv8_uXv8/job/Kbin_uxv8_uXv8__ecto_ros__ubuntu_xenial_arm64__binary/
http://build.ros.org/view/Jbin_arm_uThf/job/Jbin_arm_uThf__ecto_ros__ubuntu_trusty_armhf__binary/
