### PR TITLE
[lunar] blacklist avt_vimba_camera for arm64

### DIFF
--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - mikael+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+- avt_vimba_camera
 sync:
   package_count: 300
 repositories:

--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - mikael+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+- avt_vimba_camera
 sync:
   package_count: 300
 repositories:


### PR DESCRIPTION
`avt_vimba_camera` supports [only arches](https://github.com/srv/avt_vimba_camera/blob/45345aa9c12bb10df3f3a060c451f3e68893c971/CMakeLists.txt#L50-L70) x86, x64 and armv7, so needs to be blacklisted for arm64.