### PR TITLE
comment out EOL yakkety from build file

### DIFF
--- a/lunar/release-build.yaml
+++ b/lunar/release-build.yaml
@@ -53,8 +53,9 @@ targets:
   ubuntu:
     xenial:
       amd64:
-    yakkety:
-      amd64:
+    # EOLed
+    # yakkety:
+    #   amd64:
     zesty:
       amd64:
 type: release-build


### PR DESCRIPTION
Disabling yakkety
follow-up of https://discourse.ros.org/t/suspension-of-debian-packaging-for-eol-ubuntu-yakkety/2444