### PR TITLE
round to nearest hundred kinetic and lunar thresholds

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -25,7 +25,7 @@ package_blacklist:
 - schunk_canopen_driver
 - ueye
 sync:
-  package_count: 1100
+  package_count: 1300
 repositories:
   keys:
   - |

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 1200
+  package_count: 1500
 repositories:
   keys:
   - |

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -27,7 +27,7 @@ package_blacklist:
 - ueye
 - ueye_cam
 sync:
-  package_count: 1100
+  package_count: 1300
 repositories:
   keys:
   - |

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -16,7 +16,7 @@ package_blacklist:
 - rqt_multiplot
 - schunk_canopen_driver
 sync:
-  package_count: 1100
+  package_count: 1400
 repositories:
   keys:
   - |

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -26,7 +26,7 @@ package_blacklist:
 - ueye
 - ueye_cam
 sync:
-  package_count: 1100
+  package_count: 1300
 repositories:
   keys:
   - |

--- a/lunar/release-build.yaml
+++ b/lunar/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - mikael+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 300
+  package_count: 500
 repositories:
   keys:
   - |

--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -14,7 +14,7 @@ notifications:
 package_blacklist:
 - avt_vimba_camera
 sync:
-  package_count: 300
+  package_count: 500
 repositories:
   keys:
   - |

--- a/lunar/release-stretch-build.yaml
+++ b/lunar/release-stretch-build.yaml
@@ -13,7 +13,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 300
+  package_count: 500
 repositories:
   keys:
   - |

--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -14,7 +14,7 @@ notifications:
 package_blacklist:
 - avt_vimba_camera
 sync:
-  package_count: 300
+  package_count: 500
 repositories:
   keys:
   - |

--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -14,7 +14,7 @@ notifications:
 package_blacklist:
 - octovis
 sync:
-  package_count: 300
+  package_count: 500
 repositories:
   keys:
   - |


### PR DESCRIPTION
I kept all the kinetic arm thresholds at the same level even if they could sometimes have a different ones.
Otherwise all of them have been rounded to the nearest inferior hundred

For lunar there is not much margin given that we're around 515 packages released but that should be ok given that we get new packages pretty often