### PR TITLE
Blacklist libfranka on Debian Jessie

### DIFF
--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -15,6 +15,7 @@ package_blacklist:
 - ardrone_autonomy
 - avt_vimba_camera
 - hrpsys
+- libfranka
 - mongodb_store
 - nao_meshes
 - naoqi_dcm_driver

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+- libfranka
 - rospilot
 - rqt_multiplot
 - schunk_canopen_driver


### PR DESCRIPTION
libfranka needs at least GCC 5 to compile. Jessie only has GCC 4.9.