### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,25 @@ ros_buildfarm_config
 
 The configuration for the ROS buildfarm available under http://build.ros.org.
 
-The `master` branch is from where we run our testing farm and is the recommended place to fork from. 
+The `master` branch is from where we run our testing farm and is the recommended place to fork from.
 
 The `production` branch is what we actually run on http://build.ros.org Please do not fork from that version as it does things like turn on maintainer emails which are not appropriate for a private fork. Doing that will cause maintainers to get emails both from the main buildfarm run by OSRF, as well as duplicates from any private buildfarm which is running.
 
-The two branches should be maintained as closely as possible. 
+The two branches should be maintained as closely as possible.
 
-To deploy a custom buildfarm using this configuration you might want to use the
-[ros_buildfarm](https://github.com/ros-infrastructure/ros_buildfarm)
-repository.
+To deploy a custom buildfarm using this configuration you might want to use the [ros_buildfarm](https://github.com/ros-infrastructure/ros_buildfarm) repository.
 
-#Contributing guidelines
+# Contributing guidelines
 
 ## Branch hygiene
+
 Be careful about which branch you fork from and submit a pull request to.
 
 If you are contributing a configuration change (e.g. changing the values of keys) to be deployed on build.ros.org, make a pull request to the `production` branch.
 
 If you are contributing a change to be deployed on the testing farm or a more structural change, make a pull request to the `master` branch.
 
-##Guide to blacklisting packages
+## Guide to blacklisting packages
 
 If you wish to blacklist a package on build.ros.org, submit a pull request to `production` doing the following:
 


### PR DESCRIPTION
Without spaces between `#` and the text (e.g. `#Contributing guidelines`), Github doesn't format this as a heading (see https://github.com/ros-infrastructure/ros_buildfarm_config/blob/master/README.md#branch-hygiene)