### PR TITLE
blacklist ros_peerjs on xenial arm64

### DIFF
--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -21,6 +21,7 @@ package_blacklist:
 - nerian_sp1
 - octovis
 - pepper_meshes
+- ros_peerjs
 - rqt_multiplot
 - schunk_canopen_driver
 - ueye


### PR DESCRIPTION
Following up: https://github.com/easymov/ros_peerjs-release/issues/1#issuecomment-342188269