### PR TITLE
disable rosjava_boostrap on jessie due to SSL issues

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -22,6 +22,7 @@ package_blacklist:
 - nerian_sp1
 - octovis
 - pepper_meshes
+- rosjava_bootstrap
 - schunk_canopen_driver
 - ueye
 sync:

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -23,6 +23,7 @@ package_blacklist:
 - nerian_sp1
 - octovis
 - pepper_meshes
+- rosjava_bootstrap
 - rospilot
 - rqt_multiplot
 - schunk_canopen_driver

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -13,6 +13,7 @@ notifications:
   maintainers: true
 package_blacklist:
 - libfranka
+- rosjava_bootstrap
 - rospilot
 - rqt_multiplot
 - schunk_canopen_driver

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -22,6 +22,7 @@ package_blacklist:
 - octovis
 - pepper_meshes
 - ros_peerjs
+- rosjava_bootstrap
 - rqt_multiplot
 - schunk_canopen_driver
 - ueye


### PR DESCRIPTION
https://github.com/rosjava/rosjava_bootstrap/issues/61

http://build.ros.org/view/Kbin_dj_dJ64/job/Kbin_dj_dJ64__rosjava_bootstrap__debian_jessie_amd64__binary/
http://build.ros.org/view/Kbin_dj_dJ64/job/Kbin_djv8_dJv8__rosjava_bootstrap__debian_jessie_arm64__binary/
