### PR TITLE
Add melodic.

### DIFF
--- a/PRIORITY_NOTES.md
+++ b/PRIORITY_NOTES.md
@@ -1,0 +1,17 @@
+This file contains some notes on the Jenkins job priorities that are configured in this repository.
+
+The ROS buildfarm is currently setup with a Jenkins plugin that manages job priorities.  The priorities are inverse numerically based; that is, a lower number means a higher priority.  As of this writing, the buildfarm is configured to have a range of 1 to 109.  There are periodic maintenance jobs that use priorities 1 to 49, thus those priorities should never be used for distribution jobs.
+
+There are currently 6 classes of distribution jobs that the buildfarm runs.  Within each class, the ROS distributions should be in release order (newest ROS release has highest priority).  To make it so that we don't have to change the priorities on every release, we have defined some ranges for the classes, listed in the table below:
+
+| Job Type                     | Numeric Range |
+| ---------------------------- |:-------------:|
+| Pull Request                 | 50 - 59       |
+| Commit                       | 60 - 69       |
+| Source                       | 70 - 79       |
+| Basic Binary (amd64)         | 80 - 89       |
+| Documentation                | 90 - 99       |
+| Extended Architecture Binary | 100 - 109     |
+
+
+To add jobs for a new distribution, find the newest currently existing distribution within a class, subtract one from the priority, and set that to the priority for the new distribution.  For instance, assume we want to add a Pull Request job for N-Turtle to the list of distributions.  Further assume that the Pull Request job for M-Turtle has priority 55.  Therefore, the Pull Request job for N-Turtle would 54.

--- a/PRIORITY_NOTES.md
+++ b/PRIORITY_NOTES.md
@@ -6,12 +6,12 @@ There are currently 6 classes of distribution jobs that the buildfarm runs.  Wit
 
 | Job Type                     | Numeric Range |
 | ---------------------------- |:-------------:|
-| Pull Request                 | 50 - 59       |
-| Commit                       | 60 - 69       |
-| Source                       | 70 - 79       |
-| Basic Binary (amd64)         | 80 - 89       |
-| Documentation                | 90 - 99       |
-| Extended Architecture Binary | 100 - 109     |
+| Pull Request                 | 40 - 49       |
+| Commit                       | 50 - 59       |
+| Source                       | 60 - 69       |
+| Basic Binary (amd64)         | 70 - 79       |
+| Documentation                | 80 - 89       |
+| Extended Architecture Binary | 90 - 99       |
 
 
-To add jobs for a new distribution, find the newest currently existing distribution within a class, subtract one from the priority, and set that to the priority for the new distribution.  For instance, assume we want to add a Pull Request job for N-Turtle to the list of distributions.  Further assume that the Pull Request job for M-Turtle has priority 55.  Therefore, the Pull Request job for N-Turtle would 54.
+To add jobs for a new distribution, find the newest currently existing distribution within a class, subtract one from the priority, and set that to the priority for the new distribution.  For instance, assume we want to add a Pull Request job for N-Turtle to the list of distributions.  Further assume that the Pull Request job for M-Turtle has priority 55.  Therefore, the Pull Request job for N-Turtle would be 54.  The current list of priorities can be assessed by running the `list_priorities.py` program from the top-level of this repository.

--- a/PRIORITY_NOTES.md
+++ b/PRIORITY_NOTES.md
@@ -1,17 +1,26 @@
 This file contains some notes on the Jenkins job priorities that are configured in this repository.
 
-The ROS buildfarm is currently setup with a Jenkins plugin that manages job priorities.  The priorities are inverse numerically based; that is, a lower number means a higher priority.  As of this writing, the buildfarm is configured to have a range of 1 to 109.  There are periodic maintenance jobs that use priorities 1 to 49, thus those priorities should never be used for distribution jobs.
+The ROS buildfarm is currently setup with a Jenkins plugin that manages job priorities.
+The priorities are inverse numerically based; that is, a lower number means a higher priority.
+As of this writing, the buildfarm is configured to have a range of 1 to 99.
+There are periodic maintenance jobs that use priorities 1 to 39, thus those priorities should never be used for distribution jobs.
 
-There are currently 6 classes of distribution jobs that the buildfarm runs.  Within each class, the ROS distributions should be in release order (newest ROS release has highest priority).  To make it so that we don't have to change the priorities on every release, we have defined some ranges for the classes, listed in the table below:
+There are currently 6 classes of distribution jobs that the buildfarm runs.
+Within each class, the ROS distributions should be in release order (newest ROS release has highest priority).
+To make it so that we don't have to change the priorities on every release, we have defined some ranges for the classes, listed in the table below:
 
 | Job Type                     | Numeric Range |
 | ---------------------------- |:-------------:|
 | Pull Request                 | 40 - 49       |
 | Commit                       | 50 - 59       |
 | Source                       | 60 - 69       |
-| Basic Binary (amd64)         | 70 - 79       |
+| Basic Binary (x86/amd64)     | 70 - 79       |
 | Documentation                | 80 - 89       |
 | Extended Architecture Binary | 90 - 99       |
 
 
-To add jobs for a new distribution, find the newest currently existing distribution within a class, subtract one from the priority, and set that to the priority for the new distribution.  For instance, assume we want to add a Pull Request job for N-Turtle to the list of distributions.  Further assume that the Pull Request job for M-Turtle has priority 55.  Therefore, the Pull Request job for N-Turtle would be 54.  The current list of priorities can be assessed by running the `list_priorities.py` program from the top-level of this repository.
+To add jobs for a new distribution, find the newest currently existing distribution within a class, subtract one from the priority, and set that to the priority for the new distribution.
+For instance, assume we want to add a Pull Request job for N-Turtle to the list of distributions.
+Further assume that the Pull Request job for M-Turtle has priority 55.
+Therefore, the Pull Request job for N-Turtle would be 54.
+The current list of priorities can be assessed by running the `list_priorities.py` program from the top-level of this repository.

--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -10,7 +10,7 @@ doc_repositories:
 - https://github.com/ros-infrastructure/rospkg.git
 - https://github.com/vcstools/rosinstall.git
 - https://github.com/vcstools/vcstools.git
-jenkins_job_priority: 100
+jenkins_job_priority: 90
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -10,7 +10,7 @@ doc_repositories:
 - https://github.com/ros-infrastructure/rospkg.git
 - https://github.com/vcstools/rosinstall.git
 - https://github.com/vcstools/vcstools.git
-jenkins_job_priority: 88
+jenkins_job_priority: 100
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -10,7 +10,7 @@ doc_repositories:
 - https://github.com/ros-infrastructure/rospkg.git
 - https://github.com/vcstools/rosinstall.git
 - https://github.com/vcstools/vcstools.git
-jenkins_job_priority: 90
+jenkins_job_priority: 80
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/index.yaml
+++ b/index.yaml
@@ -57,6 +57,21 @@ distributions:
       uxv8: lunar/release-xenial-arm64-build.yaml
     source_builds:
       default: lunar/source-build.yaml
+  melodic:
+    doc_builds:
+      default: melodic/doc-build.yaml
+      released-packages-without-doc-job: melodic/doc-released-build.yaml
+    notification_emails:
+    - ros-buildfarm-melodic@googlegroups.com
+    - clalancette+buildfarm@osrfoundation.org
+    release_builds:
+      default: melodic/release-build.yaml
+      ds: melodic/release-stretch-build.yaml
+      dsv8: melodic/release-stretch-arm64-build.yaml
+      uxhf: melodic/release-armhf-build.yaml
+      uxv8: melodic/release-arm64-build.yaml
+    source_builds:
+      default: melodic/source-build.yaml
 doc_builds:
   independent-packages: doc-independent-build.yaml
 jenkins_url: http://build.ros.org

--- a/index.yaml
+++ b/index.yaml
@@ -68,8 +68,8 @@ distributions:
       default: melodic/release-build.yaml
       ds: melodic/release-stretch-build.yaml
       dsv8: melodic/release-stretch-arm64-build.yaml
-      uxhf: melodic/release-armhf-build.yaml
-      uxv8: melodic/release-arm64-build.yaml
+      ubhf: melodic/release-armhf-build.yaml
+      ubv8: melodic/release-arm64-build.yaml
     source_builds:
       default: melodic/source-build.yaml
 doc_builds:

--- a/indigo/doc-build.yaml
+++ b/indigo/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 95
+jenkins_job_priority: 99
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/indigo/doc-build.yaml
+++ b/indigo/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 99
+jenkins_job_priority: 89
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/indigo/doc-build.yaml
+++ b/indigo/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 105
+jenkins_job_priority: 95
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/indigo/doc-build.yaml
+++ b/indigo/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 92
+jenkins_job_priority: 105
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/indigo/doc-released-build.yaml
+++ b/indigo/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 95
+jenkins_job_priority: 99
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/indigo/doc-released-build.yaml
+++ b/indigo/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 92
+jenkins_job_priority: 105
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/indigo/doc-released-build.yaml
+++ b/indigo/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 99
+jenkins_job_priority: 89
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/indigo/doc-released-build.yaml
+++ b/indigo/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 105
+jenkins_job_priority: 95
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 109
+jenkins_binary_job_priority: 99
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 69
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 86
+jenkins_binary_job_priority: 105
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 82
 jenkins_source_job_timeout: 30

--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 97
+jenkins_binary_job_priority: 86
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 82
 jenkins_source_job_timeout: 30

--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 105
+jenkins_binary_job_priority: 109
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 82
+jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/indigo/release-build.yaml
+++ b/indigo/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 87
+jenkins_binary_job_priority: 89
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 82
+jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/indigo/release-build.yaml
+++ b/indigo/release-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 86
+jenkins_binary_job_priority: 87
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 82
 jenkins_source_job_timeout: 30

--- a/indigo/release-build.yaml
+++ b/indigo/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 89
+jenkins_binary_job_priority: 79
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 69
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/indigo/source-build.yaml
+++ b/indigo/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 69
+jenkins_commit_job_priority: 59
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 59
+jenkins_pull_request_job_priority: 49
 notifications:
   committers: true
   emails:

--- a/indigo/source-build.yaml
+++ b/indigo/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 72
+jenkins_commit_job_priority: 69
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 62
+jenkins_pull_request_job_priority: 59
 notifications:
   committers: true
   emails:

--- a/jade/doc-build.yaml
+++ b/jade/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 94
+jenkins_job_priority: 98
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/jade/doc-build.yaml
+++ b/jade/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 104
+jenkins_job_priority: 94
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/jade/doc-build.yaml
+++ b/jade/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 98
+jenkins_job_priority: 88
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/jade/doc-build.yaml
+++ b/jade/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 91
+jenkins_job_priority: 104
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/jade/doc-released-build.yaml
+++ b/jade/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 94
+jenkins_job_priority: 98
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/jade/doc-released-build.yaml
+++ b/jade/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 104
+jenkins_job_priority: 94
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/jade/doc-released-build.yaml
+++ b/jade/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 91
+jenkins_job_priority: 104
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/jade/doc-released-build.yaml
+++ b/jade/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 98
+jenkins_job_priority: 88
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 96
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 81
 jenkins_source_job_timeout: 30

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 104
+jenkins_binary_job_priority: 108
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 81
+jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 104
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 81
 jenkins_source_job_timeout: 30

--- a/jade/release-armhf-build.yaml
+++ b/jade/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 108
+jenkins_binary_job_priority: 98
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 78
+jenkins_source_job_priority: 68
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/jade/release-build.yaml
+++ b/jade/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 88
+jenkins_binary_job_priority: 78
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 78
+jenkins_source_job_priority: 68
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/jade/release-build.yaml
+++ b/jade/release-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 86
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 81
 jenkins_source_job_timeout: 30

--- a/jade/release-build.yaml
+++ b/jade/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 86
+jenkins_binary_job_priority: 88
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 81
+jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/jade/source-build.yaml
+++ b/jade/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 71
+jenkins_commit_job_priority: 68
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 61
+jenkins_pull_request_job_priority: 58
 notifications:
   committers: true
   emails:

--- a/jade/source-build.yaml
+++ b/jade/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 68
+jenkins_commit_job_priority: 58
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 58
+jenkins_pull_request_job_priority: 48
 notifications:
   committers: true
   emails:

--- a/kinetic/doc-build.yaml
+++ b/kinetic/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 97
+jenkins_job_priority: 87
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/kinetic/doc-build.yaml
+++ b/kinetic/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 90
+jenkins_job_priority: 103
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/kinetic/doc-build.yaml
+++ b/kinetic/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 93
+jenkins_job_priority: 97
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/kinetic/doc-build.yaml
+++ b/kinetic/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 103
+jenkins_job_priority: 93
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/kinetic/doc-released-build.yaml
+++ b/kinetic/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 103
+jenkins_job_priority: 93
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/doc-released-build.yaml
+++ b/kinetic/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 90
+jenkins_job_priority: 103
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/doc-released-build.yaml
+++ b/kinetic/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 93
+jenkins_job_priority: 97
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/doc-released-build.yaml
+++ b/kinetic/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 97
+jenkins_job_priority: 87
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 103
+jenkins_binary_job_priority: 107
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 80
+jenkins_source_job_priority: 77
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 103
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 107
+jenkins_binary_job_priority: 97
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 77
+jenkins_source_job_priority: 67
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 95
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 84
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 87
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 80
+jenkins_source_job_priority: 77
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 87
+jenkins_binary_job_priority: 77
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 77
+jenkins_source_job_priority: 67
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 103
+jenkins_binary_job_priority: 107
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 80
+jenkins_source_job_priority: 77
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 103
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 107
+jenkins_binary_job_priority: 97
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 77
+jenkins_source_job_priority: 67
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 95
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 84
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 87
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 80
+jenkins_source_job_priority: 77
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 87
+jenkins_binary_job_priority: 77
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 77
+jenkins_source_job_priority: 67
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 103
+jenkins_binary_job_priority: 107
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 80
+jenkins_source_job_priority: 77
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 103
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 107
+jenkins_binary_job_priority: 97
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 77
+jenkins_source_job_priority: 67
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 95
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 80
 jenkins_source_job_timeout: 30

--- a/kinetic/source-build.yaml
+++ b/kinetic/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 70
+jenkins_commit_job_priority: 67
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 60
+jenkins_pull_request_job_priority: 56
 notifications:
   committers: true
   compiler_warnings: true

--- a/kinetic/source-build.yaml
+++ b/kinetic/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 67
+jenkins_commit_job_priority: 57
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 56
+jenkins_pull_request_job_priority: 47
 notifications:
   committers: true
   compiler_warnings: true

--- a/kinetic/source-jessie-build.yaml
+++ b/kinetic/source-jessie-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 70
+jenkins_commit_job_priority: 67
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 60
+jenkins_pull_request_job_priority: 56
 notifications:
   committers: true
   compiler_warnings: true

--- a/kinetic/source-jessie-build.yaml
+++ b/kinetic/source-jessie-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 67
+jenkins_commit_job_priority: 57
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 56
+jenkins_pull_request_job_priority: 47
 notifications:
   committers: true
   compiler_warnings: true

--- a/lunar/doc-build.yaml
+++ b/lunar/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 102
+jenkins_job_priority: 92
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/lunar/doc-build.yaml
+++ b/lunar/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 96
+jenkins_job_priority: 86
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/lunar/doc-build.yaml
+++ b/lunar/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 92
+jenkins_job_priority: 96
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/lunar/doc-build.yaml
+++ b/lunar/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 89
+jenkins_job_priority: 102
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/lunar/doc-released-build.yaml
+++ b/lunar/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 92
+jenkins_job_priority: 96
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/lunar/doc-released-build.yaml
+++ b/lunar/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 96
+jenkins_job_priority: 86
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/lunar/doc-released-build.yaml
+++ b/lunar/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 89
+jenkins_job_priority: 102
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/lunar/doc-released-build.yaml
+++ b/lunar/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 102
+jenkins_job_priority: 92
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-build.yaml
+++ b/lunar/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 84
+jenkins_binary_job_priority: 86
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 76
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-build.yaml
+++ b/lunar/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 86
+jenkins_binary_job_priority: 76
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 76
+jenkins_source_job_priority: 66
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-build.yaml
+++ b/lunar/release-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 84
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 106
+jenkins_binary_job_priority: 96
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 76
+jenkins_source_job_priority: 66
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 84
+jenkins_binary_job_priority: 101
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 94
+jenkins_binary_job_priority: 84
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 101
+jenkins_binary_job_priority: 106
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 76
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-stretch-build.yaml
+++ b/lunar/release-stretch-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 84
+jenkins_binary_job_priority: 86
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 76
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-stretch-build.yaml
+++ b/lunar/release-stretch-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 86
+jenkins_binary_job_priority: 76
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 76
+jenkins_source_job_priority: 66
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-stretch-build.yaml
+++ b/lunar/release-stretch-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 84
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 106
+jenkins_binary_job_priority: 96
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 76
+jenkins_source_job_priority: 66
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 84
+jenkins_binary_job_priority: 101
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 94
+jenkins_binary_job_priority: 84
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 101
+jenkins_binary_job_priority: 106
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 76
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 106
+jenkins_binary_job_priority: 96
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 76
+jenkins_source_job_priority: 66
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 84
+jenkins_binary_job_priority: 101
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 94
+jenkins_binary_job_priority: 84
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 79
 jenkins_source_job_timeout: 30

--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 101
+jenkins_binary_job_priority: 106
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 76
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/lunar/source-build.yaml
+++ b/lunar/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 66
+jenkins_commit_job_priority: 56
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 57
+jenkins_pull_request_job_priority: 46
 notifications:
   committers: true
   compiler_warnings: true

--- a/lunar/source-build.yaml
+++ b/lunar/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 69
+jenkins_commit_job_priority: 66
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 59
+jenkins_pull_request_job_priority: 57
 notifications:
   committers: true
   compiler_warnings: true

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -1,0 +1,58 @@
+%YAML 1.1
+# ROS buildfarm doc-build file
+---
+canonical_base_url: http://docs.ros.org
+documentation_type: rosdoc_lite
+jenkins_job_priority: 89
+jenkins_job_timeout: 120
+notifications:
+  committers: false
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/testing
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: doc-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_host: ros.osuosl.org
+upload_root: /home/rosbot/docs
+upload_user: rosbot
+version: 2

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 95
+jenkins_job_priority: 85
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 101
+jenkins_job_priority: 91
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 91
+jenkins_job_priority: 95
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -3,7 +3,7 @@
 ---
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 89
+jenkins_job_priority: 101
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/melodic/doc-released-build.yaml
+++ b/melodic/doc-released-build.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+# ROS buildfarm doc-build file
+---
+documentation_type: released_manifest
+jenkins_job_priority: 89
+jenkins_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: doc-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/melodic/doc-released-build.yaml
+++ b/melodic/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 95
+jenkins_job_priority: 85
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/melodic/doc-released-build.yaml
+++ b/melodic/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 101
+jenkins_job_priority: 91
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/melodic/doc-released-build.yaml
+++ b/melodic/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 89
+jenkins_job_priority: 101
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/melodic/doc-released-build.yaml
+++ b/melodic/doc-released-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 documentation_type: released_manifest
-jenkins_job_priority: 91
+jenkins_job_priority: 95
 jenkins_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 105
+jenkins_binary_job_priority: 95
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 75
+jenkins_source_job_priority: 65
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -1,0 +1,59 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 95
+jenkins_binary_job_timeout: 720
+jenkins_source_job_priority: 80
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: false
+package_blacklist:
+sync:
+  package_count: 1
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  ubuntu:
+    bionic:
+      arm64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 100
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 100
+jenkins_binary_job_priority: 105
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 78
+jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 95
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 80
+jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -10,7 +10,7 @@ notifications:
   emails:
   - ros-buildfarm-melodic@googlegroups.com
   - clalancette+buildfarm@osrfoundation.org
-  maintainers: false
+  maintainers: true
 package_blacklist:
 sync:
   package_count: 1

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 94
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 600
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 105
+jenkins_binary_job_priority: 95
 jenkins_binary_job_timeout: 600
-jenkins_source_job_priority: 75
+jenkins_source_job_priority: 65
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 100
+jenkins_binary_job_priority: 105
 jenkins_binary_job_timeout: 600
-jenkins_source_job_priority: 78
+jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 100
 jenkins_binary_job_timeout: 600
 jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -1,0 +1,59 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 94
+jenkins_binary_job_timeout: 600
+jenkins_source_job_priority: 79
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: false
+package_blacklist:
+sync:
+  package_count: 1
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  ubuntu:
+    bionic:
+      armhf:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -10,7 +10,7 @@ notifications:
   emails:
   - ros-buildfarm-melodic@googlegroups.com
   - clalancette+buildfarm@osrfoundation.org
-  maintainers: false
+  maintainers: true
 package_blacklist:
 sync:
   package_count: 1

--- a/melodic/release-build.yaml
+++ b/melodic/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 78
+jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-build.yaml
+++ b/melodic/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 75
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 75
+jenkins_source_job_priority: 65
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-build.yaml
+++ b/melodic/release-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 82
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-build.yaml
+++ b/melodic/release-build.yaml
@@ -1,0 +1,60 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 82
+jenkins_binary_job_timeout: 120
+jenkins_source_job_priority: 79
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+sync:
+  package_count: 1
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  ubuntu:
+    artful:
+      amd64:
+    bionic:
+      amd64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -1,0 +1,59 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 94
+jenkins_binary_job_timeout: 600
+jenkins_source_job_priority: 79
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+package_blacklist:
+sync:
+  package_count: 1
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  debian:
+    stretch:
+      arm64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 94
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 600
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 105
+jenkins_binary_job_priority: 95
 jenkins_binary_job_timeout: 600
-jenkins_source_job_priority: 75
+jenkins_source_job_priority: 65
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 100
+jenkins_binary_job_priority: 105
 jenkins_binary_job_timeout: 600
-jenkins_source_job_priority: 78
+jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 100
 jenkins_binary_job_timeout: 600
 jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -1,0 +1,59 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 82
+jenkins_binary_job_timeout: 120
+jenkins_source_job_priority: 79
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+package_blacklist:
+sync:
+  package_count: 1
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  debian:
+    stretch:
+      amd64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 83
+jenkins_binary_job_priority: 85
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 78
+jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 85
+jenkins_binary_job_priority: 75
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 75
+jenkins_source_job_priority: 65
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -2,9 +2,9 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 82
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 79
+jenkins_source_job_priority: 78
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/melodic/source-build.yaml
+++ b/melodic/source-build.yaml
@@ -1,0 +1,58 @@
+%YAML 1.1
+# ROS buildfarm source-build file
+---
+jenkins_commit_job_priority: 69
+jenkins_job_timeout: 120
+jenkins_pull_request_job_priority: 59
+notifications:
+  committers: true
+  compiler_warnings: true
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+repositories:
+  urls:
+  - http://repositories.ros.org/ubuntu/testing
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+test_commits:
+  default: true
+test_pull_requests:
+  default: false
+type: source-build
+version: 2

--- a/melodic/source-build.yaml
+++ b/melodic/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 68
+jenkins_commit_job_priority: 65
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 58
+jenkins_pull_request_job_priority: 55
 notifications:
   committers: true
   compiler_warnings: true

--- a/melodic/source-build.yaml
+++ b/melodic/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 65
+jenkins_commit_job_priority: 55
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 55
+jenkins_pull_request_job_priority: 45
 notifications:
   committers: true
   compiler_warnings: true

--- a/melodic/source-build.yaml
+++ b/melodic/source-build.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
-jenkins_commit_job_priority: 69
+jenkins_commit_job_priority: 68
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 59
+jenkins_pull_request_job_priority: 58
 notifications:
   committers: true
   compiler_warnings: true


### PR DESCRIPTION
This adds melodic to the buildfarm configuration.  A few things to note:

1.  This is branched off of, and should be merged back into, the production branch.
1.  I ended up rationalizing the names of files in ways that made sense to me, though these files differ from what was in Lunar (but those differ from what was in Kinetic, so I'm not sure if there is a set standard).  Let me know if this is a problem.
1.  I haven't yet created the ros-buildfarm-melodic mailing list, but I will soon.
1.  I haven't tested this.  Is there any way to test before merging/deploying?

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>