### PR TITLE
EOL zesty

### DIFF
--- a/lunar/release-build.yaml
+++ b/lunar/release-build.yaml
@@ -56,8 +56,8 @@ targets:
     # EOLed
     # yakkety:
     #   amd64:
-    zesty:
-      amd64:
+    # zesty:
+    #   amd64:
 type: release-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
 version: 2


### PR DESCRIPTION
All jobs are failing on Zesty singe the debs have been moved to old-releases (https://discourse.ros.org/t/suspension-of-debian-packaging-for-eol-ubuntu-zesty-17-04/3742)

An alternative would be to update the buildfarm to pull zesty debs from old-releases until the next Lunar sync and then EOL Zesty. As there is almost no changes since last sync I suggest to just EOL zesty right away