### PR TITLE
whitelist actionlib and nodelet_core repos for stretch source/PR builds

### DIFF
--- a/melodic/source-stretch-build.yaml
+++ b/melodic/source-stretch-build.yaml
@@ -47,9 +47,11 @@ repositories:
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
 repository_whitelist:
+- actionlib
 - bond_core
 - class_loader
 - dynamic_reconfigure
+- nodelet_core
 - pluginlib
 - ros_comm
 skip_ignored_repositories: true


### PR DESCRIPTION
While these repos currently use the same branch for kinetic, adding them here allows to test Debian Stretch for both distros on incoming commits and PRs