### PR TITLE
Blacklist octovis on melodic armhf.

### DIFF
--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+- octovis
 sync:
   package_count: 1
 repositories:


### PR DESCRIPTION
The libqglviewer-dev-qt4 dependency doesn't exist on armhf,
so it can never succeed there.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>