### PR TITLE
[melodic] fix inconsistency in arm jobs timeouts

### DIFF
--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 95
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 65
 jenkins_source_job_timeout: 30
 notifications:

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_priority: 95
-jenkins_binary_job_timeout: 600
+jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 65
 jenkins_source_job_timeout: 30
 notifications:


### PR DESCRIPTION
Currently on melodic some arm jobs have a 10-hour timeout and some have a 12-hour timeout

This PR puts them all at 12hours