### PR TITLE
rachet up package count

### DIFF
--- a/indigo/release-armhf-build.yaml
+++ b/indigo/release-armhf-build.yaml
@@ -82,7 +82,7 @@ package_blacklist:
 - uwsim_osgocean
 - uwsim_osgworks
 sync:
-  package_count: 2000
+  package_count: 2200
 repositories:
   keys:
   - |

--- a/indigo/release-build.yaml
+++ b/indigo/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 2400
+  package_count: 2500
 repositories:
   keys:
   - |

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -26,7 +26,7 @@ package_blacklist:
 - schunk_canopen_driver
 - ueye
 sync:
-  package_count: 1300
+  package_count: 1800
 repositories:
   keys:
   - |

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - tfoote+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 1500
+  package_count: 1900
 repositories:
   keys:
   - |

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -32,7 +32,7 @@ package_blacklist:
 - ueye_cam
 - web_video_server
 sync:
-  package_count: 1300
+  package_count: 1800
 repositories:
   keys:
   - |

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -20,7 +20,7 @@ package_blacklist:
 - schunk_canopen_driver
 - web_video_server
 sync:
-  package_count: 1400
+  package_count: 1800
 repositories:
   keys:
   - |

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -28,7 +28,7 @@ package_blacklist:
 - ueye
 - ueye_cam
 sync:
-  package_count: 1300
+  package_count: 1800
 repositories:
   keys:
   - |

--- a/lunar/release-build.yaml
+++ b/lunar/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - mikael+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 500
+  package_count: 600
 repositories:
   keys:
   - |

--- a/lunar/release-stretch-arm64-build.yaml
+++ b/lunar/release-stretch-arm64-build.yaml
@@ -14,7 +14,7 @@ notifications:
 package_blacklist:
 - avt_vimba_camera
 sync:
-  package_count: 500
+  package_count: 600
 repositories:
   keys:
   - |

--- a/lunar/release-stretch-build.yaml
+++ b/lunar/release-stretch-build.yaml
@@ -13,7 +13,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 500
+  package_count: 600
 repositories:
   keys:
   - |

--- a/lunar/release-xenial-arm64-build.yaml
+++ b/lunar/release-xenial-arm64-build.yaml
@@ -14,7 +14,7 @@ notifications:
 package_blacklist:
 - avt_vimba_camera
 sync:
-  package_count: 500
+  package_count: 600
 repositories:
   keys:
   - |

--- a/lunar/release-xenial-armhf-build.yaml
+++ b/lunar/release-xenial-armhf-build.yaml
@@ -15,7 +15,7 @@ package_blacklist:
 - mapviz
 - octovis
 sync:
-  package_count: 500
+  package_count: 600
 repositories:
   keys:
   - |

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -13,7 +13,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 1
+  package_count: 400
 repositories:
   keys:
   - |

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -14,7 +14,7 @@ notifications:
 package_blacklist:
 - octovis
 sync:
-  package_count: 1
+  package_count: 400
 repositories:
   keys:
   - |

--- a/melodic/release-build.yaml
+++ b/melodic/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 1
+  package_count: 400
 repositories:
   keys:
   - |

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -13,7 +13,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 1
+  package_count: 400
 repositories:
   keys:
   - |

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -13,7 +13,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 1
+  package_count: 400
 repositories:
   keys:
   - |


### PR DESCRIPTION
up package count to nearest hundred.
If we were very close to the nearest hundred I removed another hundred.

@clalancette I used the status pages to do this. Using the "RED3" filter I got the number  of packages not available on main (I then double checked with the "RED1" filter in case many new packages were awaiting for their first sync)