### PR TITLE
Disable Jessie builds for Kinetic now that it's EOL

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -35,8 +35,8 @@ distributions:
     - tfoote+buildfarm@osrfoundation.org
     release_builds:
       default: kinetic/release-build.yaml
-      dj: kinetic/release-jessie-build.yaml
-      djv8: kinetic/release-jessie-arm64-build.yaml
+#      dj: kinetic/release-jessie-build.yaml
+#      djv8: kinetic/release-jessie-arm64-build.yaml
       uxhf: kinetic/release-armhf-build.yaml
       uxv8: kinetic/release-xenial-arm64-build.yaml
     source_builds:

--- a/index.yaml
+++ b/index.yaml
@@ -41,7 +41,7 @@ distributions:
       uxv8: kinetic/release-xenial-arm64-build.yaml
     source_builds:
       default: kinetic/source-build.yaml
-      dj: kinetic/source-jessie-build.yaml
+#      dj: kinetic/source-jessie-build.yaml
   lunar:
     doc_builds:
       default: lunar/doc-build.yaml


### PR DESCRIPTION
Jessie is EOL as of today https://wiki.debian.org/DebianReleases

**Hold this until we've finished the next sync.** https://discourse.ros.org/t/preparing-for-kinetic-sync-2018-06-06/5034

And manually disable the jessie jobs from the farm when merging. There's an example groovy script in #103 And later they can be removed.