### PR TITLE
Blacklist rospilot in Melodic/Stretch build

### DIFF
--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+  - rospilot
 sync:
   package_count: 400
 repositories:

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+  - rospilot
 sync:
   package_count: 400
 repositories:


### PR DESCRIPTION
Blacklist rospilot from Stretch in Melodic. See Kinetic discussion here (https://github.com/ros-infrastructure/ros_buildfarm_config/pull/85)