### PR TITLE
[melodic] EOL Ubuntu Artful

### DIFF
--- a/melodic/release-build.yaml
+++ b/melodic/release-build.yaml
@@ -51,8 +51,9 @@ repositories:
 target_repository: http://repositories.ros.org/ubuntu/building
 targets:
   ubuntu:
-    artful:
-      amd64:
+    # EOLed
+    # artful:
+    #   amd64:
     bionic:
       amd64:
 type: release-build


### PR DESCRIPTION
Last sync for artful [is out](https://discourse.ros.org/t/new-packages-for-melodic-2018-08-20/5798).
This PR disables it from the build files