### PR TITLE
[melodic/blacklists] blacklist fetch_drivers

### DIFF
--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+- fetch_drivers
 - leap_motion
 sync:
   package_count: 400

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+- fetch_drivers
 - leap_motion
 - mapviz
 - octovis

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -12,6 +12,8 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+  - fetch_drivers
+  - fetch_tools
   - leap_motion
   - rospilot
 sync:

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -12,6 +12,7 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 package_blacklist:
+  - fetch_drivers
   - rospilot
 sync:
   package_count: 400


### PR DESCRIPTION
blacklist:
 - fetch_drivers
 - fetch_tools

Please merge before ros/rosdistro#20328

- fetch_drivers includes a pre combiled binary of our drivers for the research robots, which isn't going to work on arm based systems, the binary was compiled on amd64 architecture inside of a ```FROM ros:melodic``` or ```FROM ubuntu:bionic``` based docker image so I've also blacklisted debian as we haven't tested that.
- fetch_tools is something we've only tested on Ubuntu and has been failing for months on debian.