### PR TITLE
Blacklist imagesift for kinetic on ARM

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -15,6 +15,7 @@ package_blacklist:
 - ardrone_autonomy
 - darknet
 - hrpsys
+- imagesift
 - leap_motion
 - mapviz
 - nao_meshes

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -15,6 +15,7 @@ package_blacklist:
 - ardrone_autonomy
 - avt_vimba_camera
 - hrpsys
+- imagesift
 - leap_motion
 - nao_meshes
 - naoqi_dcm_driver


### PR DESCRIPTION
This is disabling the build until https://github.com/jsk-ros-pkg/jsk_recognition/issues/2396 is resolved