### PR TITLE
Increase the melodic sync count.

### DIFF
--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -15,7 +15,7 @@ package_blacklist:
 - fetch_drivers
 - leap_motion
 sync:
-  package_count: 400
+  package_count: 1000
 repositories:
   keys:
   - |

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -17,7 +17,7 @@ package_blacklist:
 - mapviz
 - octovis
 sync:
-  package_count: 400
+  package_count: 1000
 repositories:
   keys:
   - |

--- a/melodic/release-build.yaml
+++ b/melodic/release-build.yaml
@@ -12,7 +12,7 @@ notifications:
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
 sync:
-  package_count: 400
+  package_count: 1000
 repositories:
   keys:
   - |

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -17,7 +17,7 @@ package_blacklist:
   - leap_motion
   - rospilot
 sync:
-  package_count: 400
+  package_count: 1000
 repositories:
   keys:
   - |

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -15,7 +15,7 @@ package_blacklist:
   - fetch_drivers
   - rospilot
 sync:
-  package_count: 400
+  package_count: 1000
 repositories:
   keys:
   - |


### PR DESCRIPTION
As of this commit, there are 1254 packages available on the
low end of the targets.  Set all of the sync thresholds to
1000, which means we require ~80% of packages to be successfully
built to do an automatic sync to testing.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>