### PR TITLE
[melodic/blacklists] blacklist fetch_tools

### DIFF
--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -13,6 +13,7 @@ notifications:
   maintainers: true
 package_blacklist:
   - fetch_drivers
+  - fetch_tools
   - rospilot
 sync:
   package_count: 1000

--- a/melodic/source-stretch-build.yaml
+++ b/melodic/source-stretch-build.yaml
@@ -11,6 +11,9 @@ notifications:
   - ros-buildfarm-melodic@googlegroups.com
   - clalancette+buildfarm@osrfoundation.org
   maintainers: true
+package_blacklist:
+  - fetch_drivers
+  - fetch_tools
 repositories:
   urls:
   - http://repositories.ros.org/ubuntu/testing


### PR DESCRIPTION
- adds missing blacklist in source-strech-build (related to PR #125)
- Related to fetchrobotics/fetch_tools#12 and fkie/catkin_lint#36
  python-catkin-lint is not available on Debian stretch
