### PR TITLE
move dependencies of independent doc job into build file

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -10,6 +10,15 @@ doc_repositories:
 - https://github.com/ros-infrastructure/rospkg.git
 - https://github.com/vcstools/rosinstall.git
 - https://github.com/vcstools/vcstools.git
+install_apt_packages:
+- python-catkin-pkg-modules
+- python-dateutil
+- python-wstool
+- python-yaml
+install_pip_packages:
+- catkin-sphinx
+- sphinx==1.8.5  # pinned https://github.com/ros-infrastructure/ros_buildfarm/issues/614
+- xmlschema
 jenkins_job_priority: 80
 jenkins_job_timeout: 30
 notifications:


### PR DESCRIPTION
Extracted from https://github.com/ros-infrastructure/ros_buildfarm/blob/6f06c5ec3e308e2d06b0c520ab0f2cee4074769d/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em#L39-L41 and added `xmlschema` required since ros-infrastructure/rep#190.

Effective in combination with ros-infrastructure/ros_buildfarm#618.