### PR TITLE
Revert "Blacklist imagesift for kinetic on ARM"

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -15,7 +15,6 @@ package_blacklist:
 - ardrone_autonomy
 - darknet
 - hrpsys
-- imagesift
 - leap_motion
 - mapviz
 - nao_meshes

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -15,7 +15,6 @@ package_blacklist:
 - ardrone_autonomy
 - avt_vimba_camera
 - hrpsys
-- imagesift
 - leap_motion
 - nao_meshes
 - naoqi_dcm_driver


### PR DESCRIPTION
Reverts ros-infrastructure/ros_buildfarm_config#126, since the ARM build issue was resolved in https://github.com/jsk-ros-pkg/jsk_recognition/pull/2397
see https://github.com/ros-infrastructure/ros_buildfarm_config/pull/126#issuecomment-494211739