### PR TITLE
set ROS_PYTHON_VERSION to 2 for active ROS 1 distros

### DIFF
--- a/kinetic/doc-build.yaml
+++ b/kinetic/doc-build.yaml
@@ -1,6 +1,8 @@
 %YAML 1.1
 # ROS buildfarm doc-build file
 ---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
 jenkins_job_priority: 87

--- a/kinetic/doc-released-build.yaml
+++ b/kinetic/doc-released-build.yaml
@@ -1,6 +1,8 @@
 %YAML 1.1
 # ROS buildfarm doc-build file
 ---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
 documentation_type: released_manifest
 jenkins_job_priority: 87
 jenkins_job_timeout: 30

--- a/kinetic/source-build.yaml
+++ b/kinetic/source-build.yaml
@@ -1,6 +1,8 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
 jenkins_commit_job_priority: 57
 jenkins_job_timeout: 120
 jenkins_pull_request_job_priority: 47

--- a/kinetic/source-jessie-build.yaml
+++ b/kinetic/source-jessie-build.yaml
@@ -1,6 +1,8 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
 jenkins_commit_job_priority: 57
 jenkins_job_timeout: 120
 jenkins_pull_request_job_priority: 47

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -1,6 +1,8 @@
 %YAML 1.1
 # ROS buildfarm doc-build file
 ---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
 jenkins_job_priority: 85

--- a/melodic/doc-released-build.yaml
+++ b/melodic/doc-released-build.yaml
@@ -1,6 +1,8 @@
 %YAML 1.1
 # ROS buildfarm doc-build file
 ---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
 documentation_type: released_manifest
 jenkins_job_priority: 85
 jenkins_job_timeout: 30

--- a/melodic/source-build.yaml
+++ b/melodic/source-build.yaml
@@ -1,6 +1,8 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
 collate_test_stats: true
 jenkins_commit_job_priority: 55
 jenkins_job_timeout: 120

--- a/melodic/source-stretch-build.yaml
+++ b/melodic/source-stretch-build.yaml
@@ -1,6 +1,8 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
 jenkins_commit_job_priority: 55
 jenkins_job_timeout: 120
 jenkins_pull_request_job_priority: 45


### PR DESCRIPTION
Similar to ros2/ros_buildfarm_config#26. Should make CI pass on ros/catkin#1025.