### PR TITLE
add CI build files for Noetic - on Bionic for now

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@ indigo/* @tfoote
 kinetic/* @tfoote
 lunar/* @clalancette
 melodic/* @clalancette
+noetic/* @sloretz

--- a/index.yaml
+++ b/index.yaml
@@ -73,6 +73,13 @@ distributions:
     source_builds:
       default: melodic/source-build.yaml
       ds: melodic/source-stretch-build.yaml
+  noetic:
+    ci_builds:
+      bionic-python2: noetic/ci-bionic-python2.yaml
+      bionic-python3: noetic/ci-bionic-python3.yaml
+    notification_emails:
+    - ros-buildfarm-noetic@googlegroups.com
+    - sloretz+buildfarm@openrobotics.org
 doc_builds:
   independent-packages: doc-independent-build.yaml
   rosindex: doc-rosindex.yaml

--- a/noetic/ci-bionic-python2.yaml
+++ b/noetic/ci-bionic-python2.yaml
@@ -2,6 +2,8 @@
 # ROS buildfarm ci-build file
 ---
 build_tool: 'catkin_make_isolated'
+build_environment_variables:
+  ROS_PYTHON_VERSION: '2'
 jenkins_job_priority: 50
 jenkins_job_timeout: 300
 repository_names:

--- a/noetic/ci-bionic-python2.yaml
+++ b/noetic/ci-bionic-python2.yaml
@@ -1,6 +1,7 @@
 %YAML 1.1
 # ROS buildfarm ci-build file
 ---
+build_tool: 'catkin_make_isolated'
 jenkins_job_priority: 50
 jenkins_job_timeout: 300
 repository_names:

--- a/noetic/ci-bionic-python2.yaml
+++ b/noetic/ci-bionic-python2.yaml
@@ -1,7 +1,6 @@
 %YAML 1.1
 # ROS buildfarm ci-build file
 ---
-jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300
 repository_names:

--- a/noetic/ci-bionic-python2.yaml
+++ b/noetic/ci-bionic-python2.yaml
@@ -1,0 +1,69 @@
+%YAML 1.1
+# ROS buildfarm ci-build file
+---
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_timeout: 300
+repository_names:
+  - catkin
+  - class_loader
+  - cmake_modules
+  - gencpp
+  - geneus
+  - genlisp
+  - genmsg
+  - gennodejs
+  - genpy
+  - message_generation
+  - message_runtime
+  - pluginlib
+  - ros
+  - ros_comm
+  - ros_comm_msgs
+  - rosconsole
+  - roscpp_core
+  - ros_environment
+  - roslisp
+  - rospack
+  - std_msgs
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/testing
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: ci-build
+version: 1

--- a/noetic/ci-bionic-python3.yaml
+++ b/noetic/ci-bionic-python3.yaml
@@ -1,0 +1,71 @@
+%YAML 1.1
+# ROS buildfarm ci-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_timeout: 300
+repository_names:
+  - catkin
+  - class_loader
+  - cmake_modules
+  - gencpp
+  - geneus
+  - genlisp
+  - genmsg
+  - gennodejs
+  - genpy
+  - message_generation
+  - message_runtime
+  - pluginlib
+  - ros
+  - ros_comm
+  - ros_comm_msgs
+  - rosconsole
+  - roscpp_core
+  - ros_environment
+  - roslisp
+  - rospack
+  - std_msgs
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/testing
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: ci-build
+version: 1

--- a/noetic/ci-bionic-python3.yaml
+++ b/noetic/ci-bionic-python3.yaml
@@ -3,7 +3,6 @@
 ---
 build_environment_variables:
   ROS_PYTHON_VERSION: '3'
-jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300
 repository_names:

--- a/noetic/ci-bionic-python3.yaml
+++ b/noetic/ci-bionic-python3.yaml
@@ -1,6 +1,7 @@
 %YAML 1.1
 # ROS buildfarm ci-build file
 ---
+build_tool: 'catkin_make_isolated'
 build_environment_variables:
   ROS_PYTHON_VERSION: '3'
 jenkins_job_priority: 50


### PR DESCRIPTION
The goal is to have two CI jobs for comparing the status with Python 2 and Python 3.

Since I don't think it makes sense to maintain a `.repos` file for the list of repos but instead rely on `rosinstall_generator` to generate the list based on the information available in `rosdistro` I enumerated the repository names instead of using `repos_files`. Atm this is not a supported option but I will look into making a pull request against `ros_buildfarm` to support this use case.