### PR TITLE
add rqt to Noetic CI

### DIFF
--- a/noetic/ci-bionic-python2.yaml
+++ b/noetic/ci-bionic-python2.yaml
@@ -36,6 +36,7 @@ repository_names:
   - ros_environment
   - roslisp
   - rospack
+  - rqt
   - std_msgs
   - urdfdom_py
 repositories:

--- a/noetic/ci-bionic-python3.yaml
+++ b/noetic/ci-bionic-python3.yaml
@@ -36,6 +36,7 @@ repository_names:
   - ros_environment
   - roslisp
   - rospack
+  - rqt
   - std_msgs
   - urdfdom_py
 repositories:


### PR DESCRIPTION
Add the following repos to the Noetic CI builds:
* `python_qt_binding`
* `qt_gui_core`
* `rqt`

CI builds ~(currently failing since `nodelet_core` `actionlib` is missing)~:

* Python 2: [![Build Status](http://build.ros.org/buildStatus/icon?job=Nci__bionic-python2_ubuntu_bionic_amd64&build=26)](http://build.ros.org/view/Nci/job/Nci__bionic-python2_ubuntu_bionic_amd64/26/)
* Python 3: [![Build Status](http://build.ros.org/buildStatus/icon?job=Nci__bionic-python3_ubuntu_bionic_amd64&build=54)](http://build.ros.org/view/Nci/job/Nci__bionic-python3_ubuntu_bionic_amd64/54/)