### PR TITLE
Add nodelet_core to the noetic CI jobs

### DIFF
--- a/noetic/ci-bionic-python2.yaml
+++ b/noetic/ci-bionic-python2.yaml
@@ -24,6 +24,7 @@ repository_names:
   - genpy
   - message_generation
   - message_runtime
+  - nodelet_core
   - orocos_kinematics_dynamics
   - pluginlib
   - python_qt_binding

--- a/noetic/ci-bionic-python3.yaml
+++ b/noetic/ci-bionic-python3.yaml
@@ -24,6 +24,7 @@ repository_names:
   - genpy
   - message_generation
   - message_runtime
+  - nodelet_core
   - orocos_kinematics_dynamics
   - pluginlib
   - python_qt_binding


### PR DESCRIPTION
Add the following repos to the Noetic CI builds:
* `nodelet_core`

CI builds:

* Python 2: [![Build Status](http://build.ros.org/buildStatus/icon?job=Nci__bionic-python2_ubuntu_bionic_amd64&build=28)](http://build.ros.org/view/Nci/job/Nci__bionic-python2_ubuntu_bionic_amd64/28/)
* Python 3: [![Build Status](http://build.ros.org/buildStatus/icon?job=Nci__bionic-python3_ubuntu_bionic_amd64&build=59)](http://build.ros.org/view/Nci/job/Nci__bionic-python3_ubuntu_bionic_amd64/59/)