### PR TITLE
Add image_common to the noetic CI jobs

### DIFF
--- a/noetic/ci-bionic-python2.yaml
+++ b/noetic/ci-bionic-python2.yaml
@@ -26,6 +26,7 @@ repository_names:
   - geometry
   - geometry2
   - gl_dependency
+  - image_common
   - joint_state_publisher
   - kdl_parser
   - laser_geometry

--- a/noetic/ci-bionic-python3.yaml
+++ b/noetic/ci-bionic-python3.yaml
@@ -26,6 +26,7 @@ repository_names:
   - geometry
   - geometry2
   - gl_dependency
+  - image_common
   - joint_state_publisher
   - kdl_parser
   - laser_geometry


### PR DESCRIPTION
Add the following repos to the Noetic CI builds:
* `image_common`

CI builds:

* Python 2: [![Build Status](http://build.ros.org/buildStatus/icon?job=Nci__bionic-python2_ubuntu_bionic_amd64&build=39)](http://build.ros.org/view/Nci/job/Nci__bionic-python2_ubuntu_bionic_amd64/39/)
* Python 3: [![Build Status](http://build.ros.org/buildStatus/icon?job=Nci__bionic-python3_ubuntu_bionic_amd64&build=81)](http://build.ros.org/view/Nci/job/Nci__bionic-python3_ubuntu_bionic_amd64/81/)