### PR TITLE
Add Noetic doc/source/release jobs

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -77,9 +77,21 @@ distributions:
     ci_builds:
       bionic-python2: noetic/ci-bionic-python2.yaml
       bionic-python3: noetic/ci-bionic-python3.yaml
+    doc_builds:
+      default: noetic/doc-build.yaml
+      released-packages-without-doc-job: noetic/doc-released-build.yaml
     notification_emails:
     - ros-buildfarm-noetic@googlegroups.com
     - sloretz+buildfarm@openrobotics.org
+    release_builds:
+      default: noetic/release-build.yaml
+      db: noetic/release-buster-build.yaml
+      dbv8: noetic/release-buster-arm64-build.yaml
+      ufhf: noetic/release-armhf-build.yaml
+      ufv8: noetic/release-arm64-build.yaml
+    source_builds:
+      default: noetic/source-build.yaml
+      db: noetic/source-buster-build.yaml
 doc_builds:
   independent-packages: doc-independent-build.yaml
   rosindex: doc-rosindex.yaml

--- a/noetic/doc-build.yaml
+++ b/noetic/doc-build.yaml
@@ -2,16 +2,16 @@
 # ROS buildfarm doc-build file
 ---
 build_environment_variables:
-  ROS_PYTHON_VERSION: 2
+  ROS_PYTHON_VERSION: 3
 canonical_base_url: http://docs.ros.org
 documentation_type: rosdoc_lite
-jenkins_job_priority: 85
+jenkins_job_priority: 84
 jenkins_job_timeout: 120
 notifications:
   committers: false
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
   maintainers: true
 repositories:
   keys:
@@ -50,7 +50,7 @@ repositories:
   - http://repositories.ros.org/ubuntu/testing
 targets:
   ubuntu:
-    bionic:
+    focal:
       amd64:
 type: doc-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5

--- a/noetic/doc-build.yaml
+++ b/noetic/doc-build.yaml
@@ -1,0 +1,60 @@
+%YAML 1.1
+# ROS buildfarm doc-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
+canonical_base_url: http://docs.ros.org
+documentation_type: rosdoc_lite
+jenkins_job_priority: 85
+jenkins_job_timeout: 120
+notifications:
+  committers: false
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/testing
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: doc-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_host: ros.osuosl.org
+upload_root: /home/rosbot/docs
+upload_user: rosbot
+version: 2

--- a/noetic/doc-released-build.yaml
+++ b/noetic/doc-released-build.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+# ROS buildfarm doc-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
+documentation_type: released_manifest
+jenkins_job_priority: 85
+jenkins_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: doc-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/noetic/doc-released-build.yaml
+++ b/noetic/doc-released-build.yaml
@@ -2,17 +2,17 @@
 # ROS buildfarm doc-build file
 ---
 build_environment_variables:
-  ROS_PYTHON_VERSION: 2
+  ROS_PYTHON_VERSION: 3
 documentation_type: released_manifest
-jenkins_job_priority: 85
+jenkins_job_priority: 84
 jenkins_job_timeout: 30
 notifications:
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
 targets:
   ubuntu:
-    bionic:
+    focal:
       amd64:
 type: doc-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5

--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -1,0 +1,61 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 95
+jenkins_binary_job_timeout: 720
+jenkins_source_job_priority: 65
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+package_blacklist:
+- fetch_drivers
+- leap_motion
+sync:
+  package_count: 1000
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  ubuntu:
+    bionic:
+      arm64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -2,20 +2,18 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 95
+jenkins_binary_job_priority: 94
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 65
+jenkins_source_job_priority: 64
 jenkins_source_job_timeout: 30
 notifications:
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-- fetch_drivers
-- leap_motion
 sync:
-  package_count: 1000
+  package_count: 1
 repositories:
   keys:
   - |
@@ -54,7 +52,7 @@ repositories:
 target_repository: http://repositories.ros.org/ubuntu/building
 targets:
   ubuntu:
-    bionic:
+    focal:
       arm64:
 type: release-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -1,0 +1,63 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 95
+jenkins_binary_job_timeout: 720
+jenkins_source_job_priority: 65
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+package_blacklist:
+- fetch_drivers
+- leap_motion
+- mapviz
+- octovis
+sync:
+  package_count: 1000
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  ubuntu:
+    bionic:
+      armhf:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -2,22 +2,18 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 95
+jenkins_binary_job_priority: 94
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 65
+jenkins_source_job_priority: 64
 jenkins_source_job_timeout: 30
 notifications:
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-- fetch_drivers
-- leap_motion
-- mapviz
-- octovis
 sync:
-  package_count: 1000
+  package_count: 1
 repositories:
   keys:
   - |
@@ -56,7 +52,7 @@ repositories:
 target_repository: http://repositories.ros.org/ubuntu/building
 targets:
   ubuntu:
-    bionic:
+    focal:
       armhf:
 type: release-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -1,0 +1,61 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 75
+jenkins_binary_job_timeout: 120
+jenkins_source_job_priority: 65
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+sync:
+  package_count: 1000
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  ubuntu:
+    # EOLed
+    # artful:
+    #   amd64:
+    bionic:
+      amd64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -2,17 +2,17 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 75
+jenkins_binary_job_priority: 74
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 65
+jenkins_source_job_priority: 64
 jenkins_source_job_timeout: 30
 notifications:
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
   maintainers: true
 sync:
-  package_count: 1000
+  package_count: 1
 repositories:
   keys:
   - |
@@ -51,10 +51,7 @@ repositories:
 target_repository: http://repositories.ros.org/ubuntu/building
 targets:
   ubuntu:
-    # EOLed
-    # artful:
-    #   amd64:
-    bionic:
+    focal:
       amd64:
 type: release-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -1,0 +1,63 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 95
+jenkins_binary_job_timeout: 720
+jenkins_source_job_priority: 65
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+package_blacklist:
+  - fetch_drivers
+  - fetch_tools
+  - leap_motion
+  - rospilot
+sync:
+  package_count: 1000
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  debian:
+    stretch:
+      arm64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -2,22 +2,18 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 95
+jenkins_binary_job_priority: 94
 jenkins_binary_job_timeout: 720
-jenkins_source_job_priority: 65
+jenkins_source_job_priority: 64
 jenkins_source_job_timeout: 30
 notifications:
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-  - fetch_drivers
-  - fetch_tools
-  - leap_motion
-  - rospilot
 sync:
-  package_count: 1000
+  package_count: 1
 repositories:
   keys:
   - |
@@ -56,7 +52,7 @@ repositories:
 target_repository: http://repositories.ros.org/ubuntu/building
 targets:
   debian:
-    stretch:
+    buster:
       arm64:
 type: release-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -2,21 +2,18 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_priority: 75
+jenkins_binary_job_priority: 74
 jenkins_binary_job_timeout: 120
-jenkins_source_job_priority: 65
+jenkins_source_job_priority: 64
 jenkins_source_job_timeout: 30
 notifications:
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-  - fetch_drivers
-  - fetch_tools
-  - rospilot
 sync:
-  package_count: 1000
+  package_count: 1
 repositories:
   keys:
   - |
@@ -55,7 +52,7 @@ repositories:
 target_repository: http://repositories.ros.org/ubuntu/building
 targets:
   debian:
-    stretch:
+    buster:
       amd64:
 type: release-build
 upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -1,0 +1,62 @@
+%YAML 1.1
+# ROS buildfarm release-build file
+---
+abi_incompatibility_assumed: true
+jenkins_binary_job_priority: 75
+jenkins_binary_job_timeout: 120
+jenkins_source_job_priority: 65
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+package_blacklist:
+  - fetch_drivers
+  - fetch_tools
+  - rospilot
+sync:
+  package_count: 1000
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/building
+target_repository: http://repositories.ros.org/ubuntu/building
+targets:
+  debian:
+    stretch:
+      amd64:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/noetic/source-build.yaml
+++ b/noetic/source-build.yaml
@@ -1,0 +1,61 @@
+%YAML 1.1
+# ROS buildfarm source-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
+collate_test_stats: true
+jenkins_commit_job_priority: 55
+jenkins_job_timeout: 120
+jenkins_pull_request_job_priority: 45
+notifications:
+  committers: true
+  compiler_warnings: true
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/testing
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+test_commits:
+  default: true
+test_pull_requests:
+  default: false
+type: source-build
+version: 2

--- a/noetic/source-build.yaml
+++ b/noetic/source-build.yaml
@@ -2,17 +2,17 @@
 # ROS buildfarm source-build file
 ---
 build_environment_variables:
-  ROS_PYTHON_VERSION: 2
+  ROS_PYTHON_VERSION: 3
 collate_test_stats: true
-jenkins_commit_job_priority: 55
+jenkins_commit_job_priority: 54
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 45
+jenkins_pull_request_job_priority: 44
 notifications:
   committers: true
   compiler_warnings: true
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
   maintainers: true
 repositories:
   keys:
@@ -51,7 +51,7 @@ repositories:
   - http://repositories.ros.org/ubuntu/testing
 targets:
   ubuntu:
-    bionic:
+    focal:
       amd64:
 test_commits:
   default: true

--- a/noetic/source-buster-build.yaml
+++ b/noetic/source-buster-build.yaml
@@ -1,0 +1,72 @@
+%YAML 1.1
+# ROS buildfarm source-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
+jenkins_commit_job_priority: 55
+jenkins_job_timeout: 120
+jenkins_pull_request_job_priority: 45
+notifications:
+  committers: true
+  compiler_warnings: true
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+package_blacklist:
+  - fetch_drivers
+  - fetch_tools
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/testing
+repository_whitelist:
+- actionlib
+- bond_core
+- class_loader
+- dynamic_reconfigure
+- nodelet_core
+- pluginlib
+- ros_comm
+skip_ignored_repositories: true
+targets:
+  debian:
+    stretch:
+      amd64:
+test_commits:
+  default: true
+test_pull_requests:
+  default: false
+type: source-build
+version: 2

--- a/noetic/source-buster-build.yaml
+++ b/noetic/source-buster-build.yaml
@@ -2,20 +2,18 @@
 # ROS buildfarm source-build file
 ---
 build_environment_variables:
-  ROS_PYTHON_VERSION: 2
-jenkins_commit_job_priority: 55
+  ROS_PYTHON_VERSION: 3
+jenkins_commit_job_priority: 54
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 45
+jenkins_pull_request_job_priority: 44
 notifications:
   committers: true
   compiler_warnings: true
   emails:
-  - ros-buildfarm-melodic@googlegroups.com
-  - clalancette+buildfarm@osrfoundation.org
+  - ros-buildfarm-noetic@googlegroups.com
+  - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-  - fetch_drivers
-  - fetch_tools
 repositories:
   keys:
   - |
@@ -62,7 +60,7 @@ repository_whitelist:
 skip_ignored_repositories: true
 targets:
   debian:
-    stretch:
+    buster:
       amd64:
 test_commits:
   default: true


### PR DESCRIPTION
This is mostly a copy of what #102 and ros2/ros_buildfarm_config#50 did. IIUC this can be merged once it passes review, but the jobs shouldn't be generated until ROS `focal` apt repos are ready.

First commit: Copied melodic configs

Second commit:
* `ROS_PYTHON_VERSION` 2 -> 3
* `bionic` -> `focal`
* `stretch` -> `buster`
* Make `noetic` jobs higher priority than `melodic`
* Update buildfarm emails
* Clear package blacklists
* Reset package sync threshold to 1

Third commit: Added doc/release/source jobs to index