### PR TITLE
Set ROS_PYTHON_VERSION to 3 in all noetic jobs

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -2,6 +2,8 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
 jenkins_binary_job_priority: 94
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 64

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -2,6 +2,8 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
 jenkins_binary_job_priority: 94
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 64

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -2,6 +2,8 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
 jenkins_binary_job_priority: 74
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 64

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -2,6 +2,8 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
 jenkins_binary_job_priority: 94
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 64

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -2,6 +2,8 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
 jenkins_binary_job_priority: 74
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 64


### PR DESCRIPTION
The other Noetic jobs already set `ROS_PYTHON_VERSION`. This should fix http://build.ros.org/view/Nsrc_dB/job/Nbin_db_dB64__catkin__debian_buster_amd64__binary/1/consoleFull which tried to use python 2

```
00:03:12.318 -- Found PythonInterp: /usr/bin/python (found version "2.7.16") 
00:03:12.318 -- Using PYTHON_EXECUTABLE: /usr/bin/python
00:03:12.318 -- Using Debian Python package layout
00:03:12.329 -- Could NOT find PY_em (missing: PY_EM) 
00:03:12.329 CMake Error at cmake/empy.cmake:29 (message):
00:03:12.329   Unable to find either executable 'empy' or Python module 'em'...  try
00:03:12.329   installing the package 'python-empy'
```