### PR TITLE
pin xmlschema to 1.0.18 the last release before 1.1 that supports python 2.7

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -18,7 +18,7 @@ install_apt_packages:
 install_pip_packages:
 - catkin-sphinx
 - sphinx==1.8.5  # pinned https://github.com/ros-infrastructure/ros_buildfarm/issues/614
-- xmlschema
+- xmlschema==1.0.18 # pinned because 1.1 only supports python >= 3.5 remove when upgrading to python3
 jenkins_job_priority: 80
 jenkins_job_timeout: 30
 notifications:


### PR DESCRIPTION
the doc independent jobs have been failing since 1.1 has been the latest version.

https://pypi.org/project/xmlschema/#history