### PR TITLE
Use index-v4 instead of index

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -132,7 +132,7 @@ prerequisites:
     AHNx8kw4MPUkxExgI7Sd
     =4Ofr
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
+rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
 status_page_repositories:
   default:
   - http://repositories.ros.org/ubuntu/building


### PR DESCRIPTION
I'd like to use `python_version` in https://github.com/ros-infrastructure/ros_buildfarm/pull/751