### PR TITLE
Noetic sync threshold 281 -> 376

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -15,7 +15,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 281
+  package_count: 376
 repositories:
   keys:
   - |

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -14,7 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 sync:
-  package_count: 281
+  package_count: 376
 repositories:
   keys:
   - |

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -15,7 +15,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 281
+  package_count: 376
 repositories:
   keys:
   - |

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -15,7 +15,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 281
+  package_count: 376
 repositories:
   keys:
   - |


### PR DESCRIPTION
Previous increase #168

```
released packages: 415
focal-amd64: 413 packages built
focal-arm64: 403 packages built
buster-amd64: 413 packages built
buster-arm64: 401 packages built
```

376 is about 415 * 0.9