### PR TITLE
Revert "add slam toolbox arm64 to blacklist due to current libceres failures"

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -14,9 +14,6 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-  - slam_toolbox
-  - slam_toolbox_msgs
-  - slam_toolbox_rviz
 sync:
   package_count: 376
 repositories:


### PR DESCRIPTION
Reverts ros-infrastructure/ros_buildfarm_config#172

Re-adds slam toolbox for ARM builds due to libceres.