### PR TITLE
Blacklist packages in kinetic failing on armhf

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -14,19 +14,29 @@ notifications:
 package_blacklist:
 - ardrone_autonomy
 - darknet
+- eus_nlopt
+- eusurdf
 - hrpsys
 - leap_motion
+- libntcan
+- libreflexxestype2
 - mapviz
+- mynt_eye_ros_wrapper
 - nao_meshes
 - naoqi_dcm_driver
 - naoqi_driver
 - nerian_sp1
 - novatel_oem7_driver
 - octovis
+- openrave
 - pepper_meshes
+- prosilica_gige_sdk
 - rosjava_bootstrap
 - schunk_canopen_driver
 - ueye
+- uwsim_osgocean
+- uwsim_osgworks
+- webrtc_ros
 sync:
   package_count: 2200
 repositories:


### PR DESCRIPTION
Do not continue to retry armhf builds failng consistently. 

Preparing for Kinetic Sync: https://discourse.ros.org/t/preparing-for-kinetic-sync-2020-08-20/16002

Upstream tickets for rolling back
- https://github.com/jsk-ros-pkg/jsk_control/issues/752
- https://github.com/tork-a/jsk_model_tools-release/issues/1
- https://github.com/ipa320/cob_extern/issues/110
- https://github.com/KITrobotics/ipr_extern/issues/6
- https://github.com/harjeb/libmynteye/issues/3
- https://github.com/tork-a/openrave_planning-release/issues/1
- https://github.com/ros-drivers/prosilica_gige_sdk/issues/2
- https://github.com/uji-ros-pkg/uwsim_osgocean-release/issues/2
- https://github.com/uji-ros-pkg/uwsim_osgworks-release/issues/2
- https://github.com/RobotWebTools/webrtc_ros/issues/50