### PR TITLE
ROS Noetic sync threshold 690

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -15,7 +15,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 376
+  package_count: 690
 repositories:
   keys:
   - |

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -16,7 +16,7 @@ notifications:
 package_blacklist:
 - octovis
 sync:
-  package_count: 1
+  package_count: 690
 repositories:
   keys:
   - |

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -14,7 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 sync:
-  package_count: 376
+  package_count: 690
 repositories:
   keys:
   - |

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -18,7 +18,7 @@ package_blacklist:
   - slam_toolbox_msgs
   - slam_toolbox_rviz
 sync:
-  package_count: 376
+  package_count: 690
 repositories:
   keys:
   - |

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -15,7 +15,7 @@ notifications:
   maintainers: true
 package_blacklist:
 sync:
-  package_count: 376
+  package_count: 690
 repositories:
   keys:
   - |


### PR DESCRIPTION
Previous increase #171

```
released packages: 772
focal-amd64: 767 packages built
focal-arm64: 740 packages built
focal-armhf: 737 packages built
buster-amd64: 760 packages built
buster-arm64: 735 packages built
```

690 is about 0.9 * 767