### PR TITLE
Blacklist rospilot for Buster

### DIFF
--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -15,6 +15,7 @@ notifications:
   maintainers: true
 package_blacklist:
   - ros_ign_gazebo
+  - rospilot
   - slam_toolbox
   - slam_toolbox_msgs
   - slam_toolbox_rviz

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -15,6 +15,7 @@ notifications:
   maintainers: true
 package_blacklist:
   - ros_ign_gazebo
+  - rospilot
 sync:
   package_count: 690
 repositories:


### PR DESCRIPTION
It can't build on Buster due to missing dependencies