### PR TITLE
ROS Noetic sync threshold 898

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -16,7 +16,7 @@ notifications:
 package_blacklist:
   - ros_ign_gazebo
 sync:
-  package_count: 690
+  package_count: 898
 repositories:
   keys:
   - |

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -17,7 +17,7 @@ package_blacklist:
 - octovis
 - ros_ign_gazebo
 sync:
-  package_count: 690
+  package_count: 898
 repositories:
   keys:
   - |

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -14,7 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 sync:
-  package_count: 690
+  package_count: 898
 repositories:
   keys:
   - |

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -20,7 +20,7 @@ package_blacklist:
   - slam_toolbox_msgs
   - slam_toolbox_rviz
 sync:
-  package_count: 690
+  package_count: 898
 repositories:
   keys:
   - |

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -17,7 +17,7 @@ package_blacklist:
   - ros_ign_gazebo
   - rospilot
 sync:
-  package_count: 690
+  package_count: 898
 repositories:
   keys:
   - |


### PR DESCRIPTION
Previous increase #181

```
released packages: 1005
focal-amd64: 998 packages built
focal-arm64: 947 packages built
buster-amd64: 956 packages built
buster-arm64: 896 packages built
```

898 is about 0.9 * 998