### PR TITLE
Noetic blacklist cob_monitoring

### DIFF
--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -14,6 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+  - cob_monitoring
   - novatel_oem7_driver
   - ros_ign_gazebo
   - rospilot

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -14,6 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+  - cob_monitoring
   - ros_ign_gazebo
   - rospilot
 sync:

--- a/noetic/source-buster-build.yaml
+++ b/noetic/source-buster-build.yaml
@@ -13,6 +13,8 @@ notifications:
   - ros-buildfarm-noetic@googlegroups.com
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
+package_blacklist:
+  - cob_monitoring
 repositories:
   keys:
   - |


### PR DESCRIPTION
https://answers.ros.org/question/366881/
https://github.com/ipa320/cob_command_tools/issues/289

Signed-off-by: Shane Loretz <sloretz@openrobotics.org>
Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>

@fmessmer FYI this will stop the cob_monitorying buildfarm jobs for Noetic