### PR TITLE
Use https in Jenkins URL.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -92,7 +92,7 @@ distributions:
 doc_builds:
   independent-packages: doc-independent-build.yaml
   rosindex: doc-rosindex.yaml
-jenkins_url: http://build.ros.org
+jenkins_url: https://build.ros.org
 notification_emails:
 - ros-buildfarm@googlegroups.com
 - steven+build.ros.org@openrobotics.org


### PR DESCRIPTION
I'm going to merge this directly in order to proceed with the Jenkins migration. PR is open to leave a paper trail.