### PR TITLE
Update credential id for new ROS buildfarm deployment.

### DIFF
--- a/kinetic/doc-build.yaml
+++ b/kinetic/doc-build.yaml
@@ -53,7 +53,7 @@ targets:
     xenial:
       amd64:
 type: doc-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en
 upload_user: rosbot

--- a/kinetic/doc-released-build.yaml
+++ b/kinetic/doc-released-build.yaml
@@ -15,5 +15,5 @@ targets:
     xenial:
       amd64:
 type: doc-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -80,5 +80,5 @@ targets:
     xenial:
       armhf:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/kinetic/release-build.yaml
+++ b/kinetic/release-build.yaml
@@ -59,5 +59,5 @@ targets:
       amd64:
       i386:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -75,5 +75,5 @@ targets:
     jessie:
       arm64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/kinetic/release-jessie-build.yaml
+++ b/kinetic/release-jessie-build.yaml
@@ -62,5 +62,5 @@ targets:
     jessie:
       amd64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -81,5 +81,5 @@ targets:
     xenial:
       arm64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -53,7 +53,7 @@ targets:
     bionic:
       amd64:
 type: doc-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en
 upload_user: rosbot

--- a/melodic/doc-released-build.yaml
+++ b/melodic/doc-released-build.yaml
@@ -15,5 +15,5 @@ targets:
     bionic:
       amd64:
 type: doc-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -60,5 +60,5 @@ targets:
     bionic:
       arm64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -62,5 +62,5 @@ targets:
     bionic:
       armhf:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/melodic/release-build.yaml
+++ b/melodic/release-build.yaml
@@ -57,5 +57,5 @@ targets:
     bionic:
       amd64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -62,5 +62,5 @@ targets:
     stretch:
       arm64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/melodic/release-stretch-build.yaml
+++ b/melodic/release-stretch-build.yaml
@@ -58,5 +58,5 @@ targets:
     stretch:
       amd64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/noetic/doc-build.yaml
+++ b/noetic/doc-build.yaml
@@ -53,7 +53,7 @@ targets:
     focal:
       amd64:
 type: doc-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en
 upload_user: rosbot

--- a/noetic/doc-released-build.yaml
+++ b/noetic/doc-released-build.yaml
@@ -15,5 +15,5 @@ targets:
     focal:
       amd64:
 type: doc-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -59,5 +59,5 @@ targets:
     focal:
       arm64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -60,5 +60,5 @@ targets:
     focal:
       armhf:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -56,5 +56,5 @@ targets:
     focal:
       amd64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -64,5 +64,5 @@ targets:
     buster:
       arm64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -60,5 +60,5 @@ targets:
     buster:
       amd64:
 type: release-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 version: 2


### PR DESCRIPTION
The updated buildfarm deployment uses a human-readable credential ID.

I'm going to merge this PR directly in order to proceed with verifying the buildfarm migration.