### PR TITLE
Update doc-independent job credentials for new deployment.

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -30,7 +30,7 @@ targets:
     trusty:
       amd64:
 type: doc-build
-upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+upload_credential_id: jenkins-agent
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en
 upload_user: rosbot

--- a/doc-rosindex.yaml
+++ b/doc-rosindex.yaml
@@ -7,6 +7,6 @@ doc_repositories:
 jenkins_job_priority: 90
 jenkins_job_timeout: 120
 type: doc-build
-upload_credential_id: 707af124-6f89-4292-a9b6-0e99bdc1376c
+upload_credential_id: rosindex-deploy
 upload_repository_url: git@github.com:ros-infrastructure/index.ros.org.git
 version: 2


### PR DESCRIPTION
Follow up to #191 this uses human readable credential ids for the independent doc jobs.