### PR TITLE
Pin to a supported version of xmlschema package for xenial.

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -18,7 +18,7 @@ install_apt_packages:
 install_pip_packages:
 - catkin-sphinx
 - sphinx
-- xmlschema
+- xmlschema==1.2.5
 jenkins_job_priority: 80
 jenkins_job_timeout: 30
 notifications:


### PR DESCRIPTION
Python 3.5 support was dropped in xmlschema 1.3.0:
https://github.com/sissaschool/xmlschema/blob/master/CHANGELOG.rst#v130-2020-11-09

After the completion of the build farm hosts I would like to start
migrating our utility containers to newer environments but I'm not going
to try it today.