### PR TITLE
Revert "Noetic blacklist cob_monitoring (#187)"

### DIFF
--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -14,7 +14,6 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-  - cob_monitoring
   - novatel_oem7_driver
   - ros_ign_gazebo
   - rospilot

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -14,7 +14,6 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-  - cob_monitoring
   - ros_ign_gazebo
   - rospilot
 sync:

--- a/noetic/source-buster-build.yaml
+++ b/noetic/source-buster-build.yaml
@@ -13,8 +13,6 @@ notifications:
   - ros-buildfarm-noetic@googlegroups.com
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
-package_blacklist:
-  - cob_monitoring
 repositories:
   keys:
   - |


### PR DESCRIPTION
This reverts commit a2f3ae838f3ca14b2fa177c5da6d3586110a1147.

ref https://github.com/ipa320/cob_command_tools/issues/289

@sloretz @tfoote 
blacklisting should no longer be needed
as of https://github.com/ipa320/cob_command_tools/pull/295
ref https://github.com/ros/rosdistro/pull/28071
ref https://github.com/ros/rosdistro/pull/28072

ref https://github.com/ros-infrastructure/ros_buildfarm_config/pull/189