### PR TITLE
novatel_oem7_driver: enable armhf and arm64 builds on all platforms

### DIFF
--- a/kinetic/release-armhf-build.yaml
+++ b/kinetic/release-armhf-build.yaml
@@ -26,7 +26,6 @@ package_blacklist:
 - naoqi_dcm_driver
 - naoqi_driver
 - nerian_sp1
-- novatel_oem7_driver
 - octovis
 - openrave
 - pepper_meshes

--- a/kinetic/release-jessie-arm64-build.yaml
+++ b/kinetic/release-jessie-arm64-build.yaml
@@ -22,7 +22,6 @@ package_blacklist:
 - naoqi_dcm_driver
 - naoqi_driver
 - nerian_sp1
-- novatel_oem7_driver
 - octovis
 - pepper_meshes
 - rosjava_bootstrap

--- a/kinetic/release-xenial-arm64-build.yaml
+++ b/kinetic/release-xenial-arm64-build.yaml
@@ -24,7 +24,6 @@ package_blacklist:
 - naoqi_dcm_driver
 - naoqi_driver
 - nerian_sp1
-- novatel_oem7_driver
 - octovis
 - pepper_meshes
 - prosilica_gige_sdk

--- a/melodic/release-arm64-build.yaml
+++ b/melodic/release-arm64-build.yaml
@@ -15,7 +15,6 @@ package_blacklist:
 - fetch_drivers
 - leap_motion
 - nao_meshes
-- novatel_oem7_driver
 - pepper_meshes
 sync:
   package_count: 1000

--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -16,7 +16,6 @@ package_blacklist:
 - leap_motion
 - mapviz
 - nao_meshes
-- novatel_oem7_driver
 - octovis
 - pepper_meshes
 sync:

--- a/melodic/release-stretch-arm64-build.yaml
+++ b/melodic/release-stretch-arm64-build.yaml
@@ -16,7 +16,6 @@ package_blacklist:
 - fetch_tools
 - leap_motion
 - nao_meshes
-- novatel_oem7_driver
 - pepper_meshes
 - rospilot
 sync:

--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -14,7 +14,6 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-  - novatel_oem7_driver
   - ros_ign_gazebo
 sync:
   package_count: 898

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -15,7 +15,6 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-- novatel_oem7_driver
 - octovis
 - ros_ign_gazebo
 sync:

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -14,7 +14,6 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
-  - novatel_oem7_driver
   - ros_ign_gazebo
   - rospilot
   - slam_toolbox


### PR DESCRIPTION
https://github.com/novatel/novatel_oem7_driver/issues/1 is closed now.
Release 2.1.0 added ARM support. 
