### PR TITLE
Add the doc-ros2-documentation.yaml job to the index.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -92,6 +92,7 @@ distributions:
 doc_builds:
   independent-packages: doc-independent-build.yaml
   rosindex: doc-rosindex.yaml
+  ros2doc: doc-ros2-documentation.yaml
 jenkins_url: https://build.ros.org
 notification_emails:
 - ros-buildfarm@googlegroups.com


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@nuclearsandwich I'm pretty sure I missed this on the last pass and this is required to be able to run `generate_doc_independent_job.py`.