### PR TITLE
Pin elementpath for doc-independent job

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -17,6 +17,7 @@ install_apt_packages:
 - python3-yaml
 install_pip_packages:
 - catkin-sphinx
+- elementpath==2.1.3  # pinned because newer version needs python >= 3.6: https://github.com/ros-infrastructure/rep/issues/304
 - sphinx
 - xmlschema==1.2.5
 jenkins_job_priority: 80


### PR DESCRIPTION
Workaround for https://github.com/ros-infrastructure/rep/issues/304.

Once we upgrade to a Python version >= 3.6, we should be able to unpin.

---

I'm just guessing that this will fix the issue. I'm not sure how to test it; suggestions welcome!