### PR TITLE
Blacklist build of fetch_drivers on ARM and non-Ubuntu

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -14,6 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+  - fetch_drivers
   - ros_ign_gazebo
 sync:
   package_count: 898

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -15,6 +15,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+- fetch_drivers
 - octovis
 - ros_ign_gazebo
 sync:

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -14,6 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+  - fetch_drivers
   - ros_ign_gazebo
   - rospilot
   - slam_toolbox

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -14,6 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+  - fetch_drivers
   - ros_ign_gazebo
   - rospilot
 sync:


### PR DESCRIPTION
This has precedent with Fetch's Melodic releases a while ago:
https://github.com/ros-infrastructure/ros_buildfarm_config/pull/125

I'm under the impression not much has changed, and that this will avoid a bunch of build failures.

I'll be doing a noetic release of the fetch_ros repo (which contains fetch_drivers) later this week.

Note that fetch_tools doesn't need blacklisting in noetic (it had a missing dependency on debian for melodic, iirc).