### PR TITLE
ROS Noetic sync threshold 1225, 1205, 1158, 1196, 1141

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -17,7 +17,7 @@ package_blacklist:
   - fetch_drivers
   - ros_ign_gazebo
 sync:
-  package_count: 898
+  package_count: 1205
 repositories:
   keys:
   - |

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -19,7 +19,7 @@ package_blacklist:
 - octovis
 - ros_ign_gazebo
 sync:
-  package_count: 898
+  package_count: 1158
 repositories:
   keys:
   - |

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -14,7 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 sync:
-  package_count: 898
+  package_count: 1225
 repositories:
   keys:
   - |

--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -21,7 +21,7 @@ package_blacklist:
   - slam_toolbox_msgs
   - slam_toolbox_rviz
 sync:
-  package_count: 898
+  package_count: 1141
 repositories:
   keys:
   - |

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -18,7 +18,7 @@ package_blacklist:
   - ros_ign_gazebo
   - rospilot
 sync:
-  package_count: 898
+  package_count: 1196
 repositories:
   keys:
   - |


### PR DESCRIPTION
```
released packages: 1380
focal-amd64: 1362 packages built (0.9 * count == 1225)
focal-arm64: 1339 packages built (0.9 * count == 1205)
focal-armhf: 1287 packages built (0.9 * count == 1158)
buster-amd64: 1329 packages built (0.9 * count == 1196)
buster-arm64: 1268 packages built (0.9 * count == 1141)
```

Previous increase https://github.com/ros-infrastructure/ros_buildfarm_config/pull/185

Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>