### PR TITLE
Bump the rosindex job timeout substantially

### DIFF
--- a/doc-rosindex.yaml
+++ b/doc-rosindex.yaml
@@ -5,7 +5,7 @@ documentation_type: docker_build
 doc_repositories:
 - https://github.com/ros-infrastructure/rosindex.git
 jenkins_job_priority: 90
-jenkins_job_timeout: 120
+jenkins_job_timeout: 270
 type: doc-build
 upload_credential_id: rosindex-deploy
 upload_repository_url: git@github.com:ros-infrastructure/index.ros.org.git


### PR DESCRIPTION
This configuration was changed manually in Jenkins some time ago and the config was never updated to reflect that. I have no context on what caused the job to take longer, but my guess would be that it is affected by additional packages and distributions.