### PR TITLE
Specify oversize label for rosindex job

### DIFF
--- a/doc-rosindex.yaml
+++ b/doc-rosindex.yaml
@@ -4,6 +4,7 @@
 documentation_type: docker_build
 doc_repositories:
 - https://github.com/ros-infrastructure/rosindex.git
+jenkins_job_label: buildagent &amp;&amp; oversize
 jenkins_job_priority: 90
 jenkins_job_timeout: 120
 type: doc-build


### PR DESCRIPTION
It appears that this was another job configuration that was made in production but not configured properly, and was overwritten during incident recovery.