### PR TITLE
Update doc-independent configuration for focal.

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -15,22 +15,21 @@ install_apt_packages:
 - python3-dateutil
 - python3-wstool
 - python3-yaml
+- python3-sphinx
+- python3-sphinx-rtd-theme
 install_pip_packages:
 - catkin-sphinx
-- elementpath==2.1.3  # pinned because newer version needs python >= 3.6: https://github.com/ros-infrastructure/rep/issues/304
-- jinja2==2.11.3
-- markupsafe==1.1.1
-- sphinx==3.5.4
-- xmlschema==1.2.5
+- xmlschema
 jenkins_job_priority: 80
 jenkins_job_timeout: 30
 notifications:
   emails:
   - ros-buildfarm@googlegroups.com
   - tfoote+buildfarm@osrfoundation.org
+# Targets are not used for this build file.
 targets:
   ubuntu:
-    trusty:
+    focal:
       amd64:
 type: doc-build
 upload_credential_id: jenkins-agent


### PR DESCRIPTION
The base image for this job is updating to focal.
With this change we can use more packages from the stable apt
repositories reducing the fragility, drift, and irreproducibility of
the generated documentation.

This configuration change should merge in tandem with https://github.com/ros-infrastructure/ros_buildfarm/pull/884