### PR TITLE
Ignore libpointmatcher on 32-bit platforms.

### DIFF
--- a/melodic/release-armhf-build.yaml
+++ b/melodic/release-armhf-build.yaml
@@ -19,6 +19,8 @@ package_blacklist:
 - nao_meshes
 - octovis
 - pepper_meshes
+package_ignore_list:
+- libpointmatcher  # Doesn't support 32-bit platforms. Optional for rtabmap
 sync:
   package_count: 1000
 repositories:

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -19,6 +19,8 @@ package_blacklist:
 - octovis
 - ros_ign_gazebo
 - gazebo_ros
+package_ignore_list:
+- libpointmatcher  # Doesn't support 32-bit platforms. Optional for rtabmap
 sync:
   package_count: 1158
 repositories:


### PR DESCRIPTION
libpointmatcher isn't supported on 32-bit platforms. Normally this would qualify it for the package blacklist but since it is an
opportunistic dependency for rtabmap only, rtabmap can be built without it. The rtabmap package has patches in its bloom release repository to ignore the dependency on the armhf architecture.

See https://github.com/ros/rosdistro/pull/31965#issuecomment-1058128767 for the history.

As of this commit, libpointmatcher has no other dependent packages but if others are released in the future and the libpointmatcher dependency is rigid those packages will need to be added to the blacklist directly.