### PR TITLE
blacklist aruco_ros Noetic Focal Buster arm64 and Buster amd64

### DIFF
--- a/noetic/release-buster-arm64-build.yaml
+++ b/noetic/release-buster-arm64-build.yaml
@@ -32,6 +32,8 @@ package_blacklist:
   - tesseract_urdf
   - tesseract_visualization
   - gazebo_ros
+  - aruco
+  - aruco_ros
 sync:
   package_count: 1141
 repositories:

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -27,6 +27,8 @@ package_blacklist:
   - tesseract_support
   - tesseract_urdf
   - tesseract_visualization
+  - aruco
+  - aruco_ros
 sync:
   package_count: 1196
 repositories:


### PR DESCRIPTION
Hello,

There are couple of failing buster jobs for aruco_ros packages, as it is trying to compile these packages with OpenCV 3.2, which is currently not supported by the package. It would be very helpful if you can add these packages to blacklist:

**Failing Jobs:**
https://build.ros.org/job/Nbin_db_dB64__aruco__debian_buster_amd64__binary/6/display/redirect
https://build.ros.org/job/Nbin_dbv8_dBv8__aruco__debian_buster_arm64__binary/6/display/redirect

Logs:

    23:03:35 Get:538 http://deb.debian.org/debian buster/main amd64 libopencv-core3.2 amd64 3.2.0+dfsg-6 [726 kB]
    23:03:35 Get:539 http://deb.debian.org/debian buster/main amd64 libopencv-flann3.2 amd64 3.2.0+dfsg-6 [106 kB]
    23:03:35 Get:540 http://deb.debian.org/debian buster/main amd64 libopencv-imgproc3.2 amd64 3.2.0+dfsg-6 [830 kB]
    23:03:35 Get:541 http://deb.debian.org/debian buster/main amd64 libopenexr23 amd64 2.2.1-4.1+deb10u1 [592 kB]
    23:03:35 Get:542 http://deb.debian.org/debian buster/main amd64 libopencv-imgcodecs3.2 amd64 3.2.0+dfsg-6 [99.1 kB]
    23:03:35 Get:543 http://deb.debian.org/debian buster/main amd64 libswscale5 amd64 7:4.1.8-0+deb10u1 [208 kB]
    23:03:35 Get:544 http://deb.debian.org/debian buster/main amd64 libopencv-videoio3.2 amd64 3.2.0+dfsg-6 [94.1 kB]
    23:03:35 Get:545 http://deb.debian.org/debian buster/main amd64 libopencv-highgui3.2 amd64 3.2.0+dfsg-6 [34.0 kB]
    23:03:35 Get:546 http://deb.debian.org/debian buster/main amd64 libopencv-ml3.2 amd64 3.2.0+dfsg-6 [234 kB]
    23:03:35 Get:547 http://deb.debian.org/debian buster/main amd64 libopencv-features2d3.2 amd64 3.2.0+dfsg-6 [242 kB]
    23:03:35 Get:548 http://deb.debian.org/debian buster/main amd64 libopencv-calib3d3.2 amd64 3.2.0+dfsg-6 [441 kB]

    CMake Error at CMakeLists.txt:6 (find_package):
    23:06:03   Could not find a configuration file for package "OpenCV" that is compatible
    23:06:03   with requested version "4.2.0".
    23:06:03
    23:06:03   The following configuration files were considered but not accepted:
    23:06:03
    23:06:03     /usr/share/OpenCV/OpenCVConfig.cmake, version: 3.2.0
    23:06:03
    23:06:03
    23:06:03
    23:06:03 -- Configuring incomplete, errors occurred!
    23:06:03 See also "/tmp/binarydeb/ros-noetic-aruco-3.0.1/obj-x86_64-linux-gnu/CMakeFiles/CMakeOutput.log".
    23:06:03 See also "/tmp/binarydeb/ros-noetic-aruco-3.0.1/obj-x86_64-linux-gnu/CMakeFiles/CMakeError.log".

Thank you,