### PR TITLE
Completely disable kinetic jobs.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -26,21 +26,21 @@ distributions:
 #      default: jade/release-build.yaml
 #    source_builds:
 #      default: jade/source-build.yaml
-  kinetic:
-    doc_builds:
-      default: kinetic/doc-build.yaml
-      released-packages-without-doc-job: kinetic/doc-released-build.yaml
-    notification_emails:
-    - ros-buildfarm-kinetic@googlegroups.com
-    - tfoote+buildfarm@osrfoundation.org
-    release_builds:
-      default: kinetic/release-build.yaml
+#  kinetic:
+#    doc_builds:
+#      default: kinetic/doc-build.yaml
+#      released-packages-without-doc-job: kinetic/doc-released-build.yaml
+#    notification_emails:
+#    - ros-buildfarm-kinetic@googlegroups.com
+#    - tfoote+buildfarm@osrfoundation.org
+#    release_builds:
+#      default: kinetic/release-build.yaml
 #      dj: kinetic/release-jessie-build.yaml
 #      djv8: kinetic/release-jessie-arm64-build.yaml
-      uxhf: kinetic/release-armhf-build.yaml
-      uxv8: kinetic/release-xenial-arm64-build.yaml
-    source_builds:
-      default: kinetic/source-build.yaml
+#      uxhf: kinetic/release-armhf-build.yaml
+#      uxv8: kinetic/release-xenial-arm64-build.yaml
+#    source_builds:
+#      default: kinetic/source-build.yaml
 #      dj: kinetic/source-jessie-build.yaml
 #  lunar:
 #    doc_builds:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

At least part of what is needed to address https://discourse.ros.org/t/wiki-ros-org-kinetic-tag-should-be-moved-to-eol-distro/25438