### PR TITLE
blacklist pf_driver for buster

### DIFF
--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -29,6 +29,7 @@ package_blacklist:
   - tesseract_visualization
   - aruco
   - aruco_ros
+  - pf_driver
 sync:
   package_count: 1196
 repositories:

--- a/noetic/release-buster-build.yaml
+++ b/noetic/release-buster-build.yaml
@@ -14,7 +14,10 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+  - aruco
+  - aruco_ros
   - fetch_drivers
+  - pf_driver
   - ros_ign_gazebo
   - rospilot
   - tesseract_collision
@@ -27,9 +30,6 @@ package_blacklist:
   - tesseract_support
   - tesseract_urdf
   - tesseract_visualization
-  - aruco
-  - aruco_ros
-  - pf_driver
 sync:
   package_count: 1196
 repositories:


### PR DESCRIPTION
[Jenkins job](https://build.ros.org/job/Nbin_dbv8_dBv8__pf_driver__debian_buster_arm64__binary/3/) failed since it could not find the key `libcurlpp-dev`:
```
Looking for the '.dsc' file of package 'ros-noetic-pf-driver' with version '1.2.0-1'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apt/cache.py", line 297, in __getitem__
    rawpkg = self._cache[key]
KeyError: 'libcurlpp-dev'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py", line 216, in <module>
    main()
  File "/tmp/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py", line 92, in main
    apt_cache, debian_pkg_names)
  File "/tmp/ros_buildfarm/ros_buildfarm/common.py", line 175, in get_binary_package_versions
    pkg = apt_cache[debian_pkg_name]
  File "/usr/lib/python3/dist-packages/apt/cache.py", line 299, in __getitem__
    raise KeyError('The cache has no package named %r' % key)
KeyError: "The cache has no package named 'libcurlpp-dev'"
Build step 'Execute shell' marked build as failure
```

 As seen [here](https://packages.debian.org/sid/libcurlpp-dev), it has not been released for `buster`. Hence the concerned package [pf_driver](https://github.com/PepperlFuchs/pf_lidar_ros_driver/tree/main/pf_driver) needs to be blacklisted for `buster`.

refer https://answers.ros.org/question/400344/buildfarm-fails-for-noetic-with-keyerror-libcurlpp-dev/ for details