### PR TITLE
Debian Buster is EOL - remove buildfarm jobs for it

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -82,13 +82,13 @@ distributions:
     - sloretz+buildfarm@openrobotics.org
     release_builds:
       default: noetic/release-build.yaml
-      db: noetic/release-buster-build.yaml
-      dbv8: noetic/release-buster-arm64-build.yaml
+#      db: noetic/release-buster-build.yaml
+#      dbv8: noetic/release-buster-arm64-build.yaml
       ufhf: noetic/release-armhf-build.yaml
       ufv8: noetic/release-arm64-build.yaml
     source_builds:
       default: noetic/source-build.yaml
-      db: noetic/source-buster-build.yaml
+#      db: noetic/source-buster-build.yaml
 doc_builds:
   independent-packages: doc-independent-build.yaml
   rosindex: doc-rosindex.yaml


### PR DESCRIPTION
Copied process from https://github.com/ros-infrastructure/ros_buildfarm_config/pull/188

https://github.com/ros-infrastructure/rep/pull/373