### PR TITLE
Increase Noetic Sync Threhsolds to ~1700

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -27,7 +27,7 @@ package_blacklist:
 - rosrt  # https://github.com/ros/ros_realtime/issues/15
 - skyway  # https://github.com/ntt-t3/skyway_for_ros/issues/1
 sync:
-  package_count: 1205
+  package_count: 1746
 repositories:
   keys:
   - |

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -36,7 +36,7 @@ package_blacklist:
 package_ignore_list:
 - libpointmatcher  # Doesn't support 32-bit platforms. Optional for rtabmap
 sync:
-  package_count: 1158
+  package_count: 1629
 repositories:
   keys:
   - |

--- a/noetic/release-build.yaml
+++ b/noetic/release-build.yaml
@@ -14,7 +14,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 sync:
-  package_count: 1225
+  package_count: 1780
 repositories:
   keys:
   - |


### PR DESCRIPTION
released packages: 1979
focal-amd64: 1978 packages built (0.9 * count == 1780)
focal-arm64: 1941 packages built (0.9 * count == 1746)
focal-armhf: 1810 packages built (0.9 * count == 1629)