### PR TITLE
Blacklist euslime for ARM builds

### DIFF
--- a/noetic/release-arm64-build.yaml
+++ b/noetic/release-arm64-build.yaml
@@ -15,6 +15,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+- euslime  # https://github.com/jsk-ros-pkg/euslime/issues/14
 - fetch_drivers
 - libntcan  # https://github.com/ipa320/cob_extern/issues/112
 - mocap_nokov  # https://github.com/NOKOV-MOCAP/mocap_nokov/issues/2

--- a/noetic/release-armhf-build.yaml
+++ b/noetic/release-armhf-build.yaml
@@ -15,6 +15,7 @@ notifications:
   - sloretz+buildfarm@openrobotics.org
   maintainers: true
 package_blacklist:
+- euslime  # https://github.com/jsk-ros-pkg/euslime/issues/14
 - exotica_pinocchio_dynamics_solver  # https://github.com/ipab-slmc/exotica/issues/754
 - fetch_drivers
 - gazebo_ros


### PR DESCRIPTION
Blacklisting the euslime package, which has been consistently failing on arm64 and armhf builds.

https://github.com/ros/rosdistro/pull/40413
https://github.com/jsk-ros-pkg/euslime/issues/14