### PR TITLE
Increase doc_rosindex timeout threshold

### DIFF
--- a/doc-rosindex.yaml
+++ b/doc-rosindex.yaml
@@ -6,7 +6,7 @@ doc_repositories:
 - https://github.com/ros-infrastructure/rosindex.git
 jenkins_job_label: buildagent &amp;&amp; oversize
 jenkins_job_priority: 90
-jenkins_job_timeout: 270
+jenkins_job_timeout: 300
 type: doc-build
 upload_credential_id: rosindex-deploy
 upload_repository_url: git@github.com:ros-infrastructure/index.ros.org.git


### PR DESCRIPTION
doc_rosindex job has been increasing its buildtime last weeks. This PR increases the timeout threshold to 5 hours

Check [Investigation](https://github.com/osrf/buildfarm-tools/issues/37#issuecomment-2032136857)