### PR TITLE
Update docs upload configuration.

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -32,8 +32,8 @@ targets:
     focal:
       amd64:
 type: doc-build
-upload_credential_id: jenkins-agent
+upload_credential_id: rosdocs
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en
-upload_user: rosbot
+upload_user: rosdocs
 version: 2

--- a/doc-ros2-documentation.yaml
+++ b/doc-ros2-documentation.yaml
@@ -12,8 +12,8 @@ notifications:
   emails:
   - clalancette@openrobotics.org
 type: doc-build
-upload_credential_id: jenkins-agent
+upload_credential_id: rosdocs
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en/ros2_documentation
-upload_user: rosbot
+upload_user: rosdocs
 version: 2

--- a/noetic/doc-build.yaml
+++ b/noetic/doc-build.yaml
@@ -53,8 +53,8 @@ targets:
     focal:
       amd64:
 type: doc-build
-upload_credential_id: jenkins-agent
+upload_credential_id: rosdocs
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en
-upload_user: rosbot
+upload_user: rosdocs
 version: 2


### PR DESCRIPTION
In preparation for moving docs.ros.org to the new web host, we're rolling out a new set of deploy keys as well as a dedicated user account just for the docs.

This change needs to be merged in coordination with the Jenkins deployment of the new credential and updated DNS for docs.ros.org as these keys nor configuration are valid on the current docs host.