### PR TITLE
Disable test stats for Noetic.

### DIFF
--- a/noetic/source-build.yaml
+++ b/noetic/source-build.yaml
@@ -3,7 +3,7 @@
 ---
 build_environment_variables:
   ROS_PYTHON_VERSION: 3
-collate_test_stats: true
+collate_test_stats: false
 jenkins_commit_job_priority: 54
 jenkins_job_timeout: 120
 jenkins_pull_request_job_priority: 44


### PR DESCRIPTION
This is temporary in order to resolve build failures when the publish-over-ssh plugin fails to properly authenticate after the change in docs host keys.

This can be re-enabled when something like https://github.com/ros-infrastructure/ros_buildfarm/pull/1054 is merged.