### PR TITLE
Stop building reps on build.ros.org

### DIFF
--- a/doc-independent-build.yaml
+++ b/doc-independent-build.yaml
@@ -4,7 +4,6 @@
 documentation_type: make_target
 doc_repositories:
 - https://github.com/ros-infrastructure/catkin_pkg.git
-- https://github.com/ros-infrastructure/rep.git
 - https://github.com/ros-infrastructure/rosdep.git
 - https://github.com/ros-infrastructure/rosdistro.git
 - https://github.com/ros-infrastructure/rospkg.git


### PR DESCRIPTION
We're moving things to github pages local generation.